### PR TITLE
[nemo-qml-plugin-calendar] Use notebook color if specified

### DIFF
--- a/src/calendareventcache.cpp
+++ b/src/calendareventcache.cpp
@@ -70,6 +70,8 @@ void NemoCalendarEventCache::load()
 
         QString color = settings.value("colors/" + uid, QString()).toString();
         if (color.isEmpty())
+            color = notebooks.at(ii)->color();
+        if (color.isEmpty())
             color = defaultNotebookColors.at((nextDefaultNotebookColor++) % defaultNotebookColors.count());
 
         mNotebookColors.insert(uid, color);


### PR DESCRIPTION
Previously if no setting for the notebook color was defined, the
notebook would be colored randomly.  This commit ensures that if
no explicit setting for the notebook color was defined, it should
instead attempt to use the color specified by the notebook, and
only if that is empty, to fall back to the randomly generated
color.
