### PR TITLE
[nemo-qml-plugin-calendar] Support converting event to vCalendar

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -20,6 +20,7 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(libmkcal-qt5)
 BuildRequires:  pkgconfig(libkcalcoren-qt5)
+BuildRequires:  pkgconfig(libical)
 
 %description
 %{summary}.

--- a/rpm/nemo-qml-plugin-calendar-qt5.yaml
+++ b/rpm/nemo-qml-plugin-calendar-qt5.yaml
@@ -15,6 +15,7 @@ PkgConfigBR:
     - Qt5Qml
     - libmkcal-qt5
     - libkcalcoren-qt5
+    - libical
 Files:
     - "%{_libdir}/qt5/qml/org/nemomobile/calendar/libnemocalendar.so"
     - "%{_libdir}/qt5/qml/org/nemomobile/calendar/qmldir"

--- a/rpm/nemo-qml-plugin-calendar.spec
+++ b/rpm/nemo-qml-plugin-calendar.spec
@@ -19,6 +19,7 @@ Source100:  nemo-qml-plugin-calendar.yaml
 BuildRequires:  pkgconfig(QtCore) >= 4.7.0
 BuildRequires:  pkgconfig(QtDeclarative)
 BuildRequires:  pkgconfig(libmkcal)
+BuildRequires:  pkgconfig(libical)
 Provides:   nemo-qml-plugins-calendar > 0.3.14
 Obsoletes:   nemo-qml-plugins-calendar <= 0.3.14
 

--- a/rpm/nemo-qml-plugin-calendar.yaml
+++ b/rpm/nemo-qml-plugin-calendar.yaml
@@ -14,6 +14,7 @@ PkgConfigBR:
     - QtCore >= 4.7.0
     - QtDeclarative
     - libmkcal
+    - libical
 Provides:
     - nemo-qml-plugins-calendar > 0.3.14
 Obsoletes:

--- a/src/calendarevent.h
+++ b/src/calendarevent.h
@@ -123,6 +123,7 @@ public:
 
     Q_INVOKABLE void save();
     Q_INVOKABLE void remove();
+    Q_INVOKABLE QString vCalendar(const QString &prodId = QString()) const;
 
     inline KCalCore::Event::Ptr event();
     inline const KCalCore::Event::Ptr &event() const;

--- a/src/src.pro
+++ b/src/src.pro
@@ -7,13 +7,13 @@ CONFIG += qt plugin hide_symbols
 equals(QT_MAJOR_VERSION, 4) {
     QT += declarative
     target.path = $$[QT_INSTALL_IMPORTS]/$$PLUGIN_IMPORT_PATH
-    PKGCONFIG += libkcalcoren libmkcal
+    PKGCONFIG += libkcalcoren libmkcal libical
 }
 
 equals(QT_MAJOR_VERSION, 5) {
     QT += qml
     target.path = $$[QT_INSTALL_QML]/$$PLUGIN_IMPORT_PATH
-    PKGCONFIG += libkcalcoren-qt5 libmkcal-qt5
+    PKGCONFIG += libkcalcoren-qt5 libmkcal-qt5 libical
 
     SOURCES += \
         calendarapi.cpp \


### PR DESCRIPTION
This commit adds an invokable function to the NemoCalendarEvent type
which returns the vCalendar representation of the event as a string.
This is useful for sharing the event.
