### PR TITLE
AgendaModel to show events inclusive between start and end date

### DIFF
--- a/src/calendareventcache.cpp
+++ b/src/calendareventcache.cpp
@@ -254,8 +254,9 @@ void NemoCalendarEventCache::doAgendaRefresh()
             QDate end = agenda_endDate(m);
             mKCal::ExtendedCalendar::ExpandedIncidenceList filtered;
             for (int kk = 0; kk < newEvents.count(); ++kk) {
-                if (newEvents.at(kk).first.dtStart.date() <= start &&
-                    newEvents.at(kk).first.dtEnd.date() >= end)
+                mKCal::ExtendedCalendar::ExpandedIncidenceValidity validity = newEvents.at(kk).first;
+                if ((validity.dtStart.date() < start && validity.dtEnd.date() >= start)
+                        || (validity.dtStart.date() >= start && validity.dtStart.date() <= end))
                     filtered.append(newEvents.at(kk));
             }
 


### PR DESCRIPTION
Setting end date further than start required events to be at least from start to end. Shorter events inside the range didn't show at all.
