### PR TITLE
[nemo-qml-plugin-calendar] Notebook management related changes.

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-calendar-qt5
 # << macros
 
 Summary:    Calendar plugin for Nemo Mobile
-Version:    0.0.0
+Version:    0.0.22
 Release:    1
 Group:      System/Libraries
 License:    BSD

--- a/rpm/nemo-qml-plugin-calendar-qt5.yaml
+++ b/rpm/nemo-qml-plugin-calendar-qt5.yaml
@@ -3,7 +3,7 @@ Summary: Calendar plugin for Nemo Mobile
 URL: https://github.com/nemomobile/nemo-qml-plugin-calendar
 Group: System/Libraries
 Description: "%{summary}."
-Version: 0.0.0
+Version: 0.0.22
 Release: 1
 Sources:
     - "%{name}-%{version}.tar.bz2"

--- a/src/calendaragendamodel.h
+++ b/src/calendaragendamodel.h
@@ -64,7 +64,7 @@ public:
     enum {
         EventObjectRole = Qt::UserRole,
         OccurrenceObjectRole,
-        SectionBucketRole,
+        SectionBucketRole
     };
 
     explicit NemoCalendarAgendaModel(QObject *parent = 0);

--- a/src/calendarevent.h
+++ b/src/calendarevent.h
@@ -58,6 +58,7 @@ class NemoCalendarEvent : public QObject
     Q_PROPERTY(QString color READ color NOTIFY colorChanged)
     Q_PROPERTY(QString alarmProgram READ alarmProgram WRITE setAlarmProgram NOTIFY alarmProgramChanged)
     Q_PROPERTY(bool readonly READ readonly CONSTANT)
+    Q_PROPERTY(QString calendarUid READ calendarUid NOTIFY calendarUidChanged)
 
 public:
     enum Recur {
@@ -120,8 +121,9 @@ public:
     void setAlarmProgram(const QString &);
 
     bool readonly() const;
+    QString calendarUid() const;
 
-    Q_INVOKABLE void save();
+    Q_INVOKABLE void save(const QString &calendarUid = QString());
     Q_INVOKABLE void remove();
     Q_INVOKABLE QString vCalendar(const QString &prodId = QString()) const;
 
@@ -140,6 +142,7 @@ signals:
     void reminderChanged();
     void alarmProgramChanged();
     void colorChanged();
+    void calendarUidChanged();
 
 private:
     friend class NemoCalendarEventCache;

--- a/src/calendarnotebookmodel.h
+++ b/src/calendarnotebookmodel.h
@@ -44,7 +44,9 @@ public:
         UidRole,
         DescriptionRole,
         ColorRole,
-        DefaultRole
+        DefaultRole,
+        ReadOnlyRole,
+        LocalCalendarRole
     };
 
     NemoCalendarNotebookModel();


### PR DESCRIPTION
- Add calendar uid property to event. Required by qml to select notebook for saved event.
- Fix event::realonly to return notebook readonly status where event is stored.
- Change event:save to require notebook uid. Enables moving event to other notebook.
- Fix missing colorChanged signal emit.
- Add readonly role to notebook model.
- Add localCalendar role to notebook model.
