### PR TITLE
[nemo-qml-plugin-calendar] Reset alarms when notebook get's excluded / included.

### DIFF
--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -9,7 +9,7 @@ Name:       nemo-qml-plugin-calendar-qt5
 # << macros
 
 Summary:    Calendar plugin for Nemo Mobile
-Version:    0.0.22
+Version:    0.0.24
 Release:    1
 Group:      System/Libraries
 License:    BSD
@@ -18,7 +18,7 @@ Source0:    %{name}-%{version}.tar.bz2
 Source100:  nemo-qml-plugin-calendar-qt5.yaml
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
-BuildRequires:  pkgconfig(libmkcal-qt5)
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.3.18
 BuildRequires:  pkgconfig(libkcalcoren-qt5)
 BuildRequires:  pkgconfig(libical)
 

--- a/rpm/nemo-qml-plugin-calendar-qt5.yaml
+++ b/rpm/nemo-qml-plugin-calendar-qt5.yaml
@@ -3,7 +3,7 @@ Summary: Calendar plugin for Nemo Mobile
 URL: https://github.com/nemomobile/nemo-qml-plugin-calendar
 Group: System/Libraries
 Description: "%{summary}."
-Version: 0.0.22
+Version: 0.0.24
 Release: 1
 Sources:
     - "%{name}-%{version}.tar.bz2"

--- a/src/calendarapi.h
+++ b/src/calendarapi.h
@@ -60,6 +60,10 @@ public:
 signals:
     void excludedNotebooksChanged();
 
+private:
+
+    void clearPrimedAlarms(const QStringList &calendarUids);
+    void primeAlarms(const QStringList &calendarUids);
 };
 
 #endif // CALENDARAPI_H

--- a/src/calendarnotebookmodel.cpp
+++ b/src/calendarnotebookmodel.cpp
@@ -34,6 +34,7 @@
 
 #include "calendardb.h"
 #include "calendareventcache.h"
+#include <QtCore/QSettings>
 
 NemoCalendarNotebookModel::NemoCalendarNotebookModel()
 {
@@ -44,6 +45,7 @@ NemoCalendarNotebookModel::NemoCalendarNotebookModel()
     mRoleNames[DefaultRole] = "isDefault";
     mRoleNames[ReadOnlyRole] = "readOnly";
     mRoleNames[LocalCalendarRole] = "localCalendar";
+    mRoleNames[ExcludedOrReadOnlyRole] = "excludedOrReadOnly";
 }
 
 int NemoCalendarNotebookModel::rowCount(const QModelIndex &index) const
@@ -76,6 +78,10 @@ QVariant NemoCalendarNotebookModel::data(const QModelIndex &index, int role) con
         return notebook->isReadOnly();
     case LocalCalendarRole:
         return (notebook->isMaster() && !notebook->isShared() && notebook->pluginName().isEmpty());
+    case ExcludedOrReadOnlyRole: {
+        QSettings settings("nemo", "nemo-qml-plugin-calendar");
+        return notebook->isReadOnly() || settings.value("exclude/" + notebook->uid()).toBool();
+    }
     default:
         return QVariant();
     }

--- a/src/calendarnotebookmodel.h
+++ b/src/calendarnotebookmodel.h
@@ -46,7 +46,8 @@ public:
         ColorRole,
         DefaultRole,
         ReadOnlyRole,
-        LocalCalendarRole
+        LocalCalendarRole,
+        ExcludedOrReadOnlyRole
     };
 
     NemoCalendarNotebookModel();

--- a/src/src.pro
+++ b/src/src.pro
@@ -21,7 +21,6 @@ equals(QT_MAJOR_VERSION, 5) {
         calendarnotebookmodel.cpp \
 
     HEADERS += \
-        calendarapi.cpp \
         calendarapi.h \
         calendareventquery.h \
         calendarnotebookmodel.h \
@@ -44,13 +43,13 @@ SOURCES += \
     calendarevent.cpp \
     calendaragendamodel.cpp \
     calendardb.cpp \
-    calendareventcache.cpp \
+    calendareventcache.cpp
 
 HEADERS += \
     calendarevent.h \
     calendaragendamodel.h \
     calendardb.h \
-    calendareventcache.h \
+    calendareventcache.h
 
 MOC_DIR = $$PWD/.moc
 OBJECTS_DIR = $$PWD/.obj


### PR DESCRIPTION
- Also pass list of excluded notebook uids to storage so sync wont prime new alarms to timed.

[nemo-qml-plugin-calendar] Add new role to filter out readonly and excluded calendars.

Depends on https://github.com/mer-packages/mkcal/pull/7