### PR TITLE
[nemo-qml-plugin-calendar] Emit updated() on AgendaModel refresh

### DIFF
--- a/src/calendaragendamodel.cpp
+++ b/src/calendaragendamodel.cpp
@@ -187,6 +187,8 @@ void NemoCalendarAgendaModel::doRefresh(QList<NemoCalendarEventOccurrence *> new
 
     if (oldEventCount != mEvents.count())
         emit countChanged();
+
+    emit updated();
 }
 
 int NemoCalendarAgendaModel::count() const

--- a/src/calendaragendamodel.h
+++ b/src/calendaragendamodel.h
@@ -78,6 +78,7 @@ signals:
     void countChanged();
     void startDateChanged();
     void endDateChanged();
+    void updated();
 
 protected:
     virtual QHash<int, QByteArray> roleNames() const;


### PR DESCRIPTION
The updated() signal is emitted when AgendaModel model data has been updated either as a response to changes in startDate and/or endDate, or changes in the data base.

The updated() signal does not imply that the AgendaModel has been changed, only that the contents of the model are up to date. 
