### PR TITLE
[nemo-qml-plugin-calendar] Fix empty alarm by removing alarm program support

### DIFF
--- a/src/calendardata.h
+++ b/src/calendardata.h
@@ -29,7 +29,6 @@ struct Event {
     QList<KDateTime> recurExceptionDates;
     NemoCalendarEvent::Reminder reminder;
     QString uniqueId;
-    QString alarmProgram;
     bool readonly;
     QString location;
     QString calendarUid;

--- a/src/calendarevent.cpp
+++ b/src/calendarevent.cpp
@@ -189,16 +189,6 @@ QString NemoCalendarEvent::color() const
     return mManager->getNotebookColor(mManager->getEvent(mUniqueId).calendarUid);
 }
 
-QString NemoCalendarEvent::alarmProgram() const
-{
-    return mManager->getEvent(mUniqueId).alarmProgram;
-}
-
-void NemoCalendarEvent::setAlarmProgram(const QString &program)
-{
-    mManager->setAlarmProgram(mUniqueId, program);
-}
-
 bool NemoCalendarEvent::readonly() const
 {
     return mManager->getEvent(mUniqueId).readonly;

--- a/src/calendarevent.h
+++ b/src/calendarevent.h
@@ -58,7 +58,6 @@ class NemoCalendarEvent : public QObject
     Q_PROPERTY(Reminder reminder READ reminder WRITE setReminder NOTIFY reminderChanged)
     Q_PROPERTY(QString uniqueId READ uniqueId NOTIFY uniqueIdChanged)
     Q_PROPERTY(QString color READ color NOTIFY colorChanged)
-    Q_PROPERTY(QString alarmProgram READ alarmProgram WRITE setAlarmProgram NOTIFY alarmProgramChanged)
     Q_PROPERTY(bool readonly READ readonly CONSTANT)
     Q_PROPERTY(QString calendarUid READ calendarUid NOTIFY calendarUidChanged)
     Q_PROPERTY(QString location READ location WRITE setLocation NOTIFY locationChanged)
@@ -124,9 +123,6 @@ public:
 
     QString color() const;
 
-    QString alarmProgram() const;
-    void setAlarmProgram(const QString &);
-
     bool readonly() const;
     QString calendarUid() const;
 
@@ -151,7 +147,6 @@ signals:
     void recurExceptionsChanged();
     void reminderChanged();
     void uniqueIdChanged();
-    void alarmProgramChanged();
     void colorChanged();
     void calendarUidChanged();
     void locationChanged();

--- a/src/calendarmanager.cpp
+++ b/src/calendarmanager.cpp
@@ -546,24 +546,6 @@ void NemoCalendarManager::setAllDay(const QString &uid, bool allDay)
         emit mEventObjects.value(uid)->allDayChanged();
 }
 
-void NemoCalendarManager::setAlarmProgram(const QString &uid, const QString &program)
-{
-    if (mModifiedEvents.contains(uid)) {
-        if (mModifiedEvents.value(uid).alarmProgram == program)
-            return;
-    } else {
-        if (!mEvents.contains(uid) || mEvents.value(uid).alarmProgram == program)
-            return;
-        else
-            mModifiedEvents.insert(uid, mEvents.value(uid));
-    }
-
-    mModifiedEvents[uid].alarmProgram = program;
-
-    if (mEventObjects.contains(uid) && mEventObjects.value(uid))
-        emit mEventObjects.value(uid)->alarmProgramChanged();
-}
-
 void NemoCalendarManager::setRecurrence(const QString &uid, NemoCalendarEvent::Recur recur)
 {
     if (mModifiedEvents.contains(uid)) {
@@ -772,9 +754,6 @@ void NemoCalendarManager::sendEventChangeSignals(const NemoCalendarData::Event &
     NemoCalendarEvent *eventObject = mEventObjects.value(newEvent.uniqueId);
     if (!eventObject)
         return;
-
-    if (newEvent.alarmProgram != oldEvent.alarmProgram)
-        emit eventObject->alarmProgramChanged();
 
     if (newEvent.allDay != oldEvent.allDay)
         emit eventObject->allDayChanged();

--- a/src/calendarmanager.h
+++ b/src/calendarmanager.h
@@ -67,7 +67,6 @@ public:
     // Event
     NemoCalendarData::Event getEvent(const QString& uid);
 
-    void setAlarmProgram(const QString &uid, const QString &program);
     void setAllDay(const QString &uid, bool allDay);
     void setDescription(const QString &uid, const QString &description);
     void setDisplayLabel(const QString &uid, const QString &displayLabel);

--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -178,8 +178,6 @@ void NemoCalendarWorker::saveEvent(const NemoCalendarData::Event &eventData, con
         event->setRevision(event->revision() + 1);
     }
 
-    changed = setAlarmProgram(event, eventData.alarmProgram) ? true : changed;
-
     if (event->allDay() != eventData.allDay) {
         event->setAllDay(eventData.allDay);
         changed = true;
@@ -223,28 +221,6 @@ void NemoCalendarWorker::init()
     mStorage->open();
     mStorage->registerObserver(this);
     loadNotebooks();
-}
-
-bool NemoCalendarWorker::setAlarmProgram(KCalCore::Event::Ptr &event, const QString &program)
-{
-    KCalCore::Alarm::List alarms = event->alarms();
-
-    for (int ii = 0; ii < alarms.count(); ++ii) {
-        if (alarms.at(ii)->type() == KCalCore::Alarm::Procedure
-                && alarms.at(ii)->programArguments() == event->uid()) {
-            if (alarms.at(ii)->programFile() != program) {
-                alarms[ii]->setProgramFile(program);
-                return true;
-            }
-            return false;
-        }
-    }
-
-    KCalCore::Alarm::Ptr alarm = event->newAlarm();
-    alarm->setEnabled(true);
-    alarm->setType(KCalCore::Alarm::Procedure);
-    alarm->setProcedureAlarm(program, event->uid());
-    return true;
 }
 
 NemoCalendarEvent::Recur NemoCalendarWorker::convertRecurrence(const KCalCore::Event::Ptr &event) const
@@ -622,15 +598,6 @@ NemoCalendarData::Event NemoCalendarWorker::createEventStruct(const KCalCore::Ev
 {
     NemoCalendarData::Event event;
     event.uniqueId = e->uid();
-    KCalCore::Alarm::List alarms = e->alarms();
-    for (int ii = 0; ii < alarms.count(); ++ii) {
-        if (alarms.at(ii)->type() == KCalCore::Alarm::Procedure &&
-                alarms.at(ii)->programArguments() == event.uniqueId) {
-            event.alarmProgram = alarms.at(ii)->programFile();
-            break;
-        }
-    }
-
     event.allDay = e->allDay();
     event.calendarUid = mCalendar->notebook(e);
     event.description = e->description();

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -92,7 +92,6 @@ private:
     QStringList excludedNotebooks() const;
     bool saveExcludeNotebook(const QString &notebookUid, bool exclude);
 
-    bool setAlarmProgram(KCalCore::Event::Ptr &event, const QString &program);
     bool setRecurrence(KCalCore::Event::Ptr &event, NemoCalendarEvent::Recur recur);
     bool setReminder(KCalCore::Event::Ptr &event, NemoCalendarEvent::Reminder reminder);
     bool setExceptions(KCalCore::Event::Ptr &event, const QList<KDateTime> &exceptions);

--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -44,7 +44,6 @@ void tst_CalendarEvent::initialValues()
 
     // Check default values
     QVERIFY(!event->uniqueId().isEmpty());
-    QVERIFY(event->alarmProgram().isEmpty());
     QVERIFY(!event->allDay());
     QVERIFY(event->calendarUid().isEmpty());
     QVERIFY(event->color() == "");
@@ -64,21 +63,6 @@ void tst_CalendarEvent::setters()
     NemoCalendarApi calendarApi(this);
     NemoCalendarEvent *event = calendarApi.createEvent();
     QVERIFY(event != 0);
-
-    QSignalSpy alarmProgramSpy(event, SIGNAL(alarmProgramChanged()));
-    QLatin1String alarmProgram("alarmProgram");
-    event->setAlarmProgram(alarmProgram);
-    QCOMPARE(alarmProgramSpy.count(), 1);
-    QCOMPARE(event->alarmProgram(), alarmProgram);
-
-    event->setAlarmProgram(alarmProgram);
-    QCOMPARE(alarmProgramSpy.count(), 1);
-    QCOMPARE(event->alarmProgram(), alarmProgram);
-
-    alarmProgram = QLatin1String("another alarm program");
-    event->setAlarmProgram(alarmProgram);
-    QCOMPARE(alarmProgramSpy.count(), 2);
-    QCOMPARE(event->alarmProgram(), alarmProgram);
 
     QSignalSpy allDaySpy(event, SIGNAL(allDayChanged()));
     bool allDay = !event->allDay();
@@ -141,34 +125,35 @@ void tst_CalendarEvent::testSignals()
     NemoCalendarEvent *eventB = (NemoCalendarEvent*) query.event();
     QVERIFY(eventB != 0);
 
-    QSignalSpy alarmAProgramSpy(eventA, SIGNAL(alarmProgramChanged()));
-    QSignalSpy alarmBProgramSpy(eventB, SIGNAL(alarmProgramChanged()));
-    QLatin1String alarmProgram("alarmProgram");
-    eventA->setAlarmProgram(alarmProgram);
-    QCOMPARE(alarmAProgramSpy.count(), 1);
-    QCOMPARE(alarmBProgramSpy.count(), 1);
-    QCOMPARE(eventA->alarmProgram(), alarmProgram);
-    QCOMPARE(eventB->alarmProgram(), alarmProgram);
+    QSignalSpy labelSpyA(eventA, SIGNAL(displayLabelChanged()));
+    QSignalSpy labelSpyB(eventB, SIGNAL(displayLabelChanged()));
+    QLatin1String label("event display label");
 
-    eventA->setAlarmProgram(alarmProgram);
-    QCOMPARE(alarmAProgramSpy.count(), 1);
-    QCOMPARE(alarmBProgramSpy.count(), 1);
-    QCOMPARE(eventA->alarmProgram(), alarmProgram);
-    QCOMPARE(eventB->alarmProgram(), alarmProgram);
+    eventA->setDisplayLabel(label);
+    QCOMPARE(labelSpyA.count(), 1);
+    QCOMPARE(labelSpyB.count(), 1);
+    QCOMPARE(eventA->displayLabel(), label);
+    QCOMPARE(eventB->displayLabel(), label);
 
-    alarmProgram = QLatin1String("another alarm program");
-    eventA->setAlarmProgram(alarmProgram);
-    QCOMPARE(alarmAProgramSpy.count(), 2);
-    QCOMPARE(alarmBProgramSpy.count(), 2);
-    QCOMPARE(eventA->alarmProgram(), alarmProgram);
-    QCOMPARE(eventB->alarmProgram(), alarmProgram);
+    eventA->setDisplayLabel(label);
+    QCOMPARE(labelSpyA.count(), 1);
+    QCOMPARE(labelSpyB.count(), 1);
+    QCOMPARE(eventA->displayLabel(), label);
+    QCOMPARE(eventB->displayLabel(), label);
 
-    alarmProgram = QLatin1String("yet another alarm program");
-    eventB->setAlarmProgram(alarmProgram);
-    QCOMPARE(alarmAProgramSpy.count(), 3);
-    QCOMPARE(alarmBProgramSpy.count(), 3);
-    QCOMPARE(eventA->alarmProgram(), alarmProgram);
-    QCOMPARE(eventB->alarmProgram(), alarmProgram);
+    label = QLatin1String("another event label");
+    eventA->setDisplayLabel(label);
+    QCOMPARE(labelSpyA.count(), 2);
+    QCOMPARE(labelSpyB.count(), 2);
+    QCOMPARE(eventA->displayLabel(), label);
+    QCOMPARE(eventB->displayLabel(), label);
+
+    label = QLatin1String("yet another event label");
+    eventB->setDisplayLabel(label);
+    QCOMPARE(labelSpyA.count(), 3);
+    QCOMPARE(labelSpyB.count(), 3);
+    QCOMPARE(eventA->displayLabel(), label);
+    QCOMPARE(eventB->displayLabel(), label);
 }
 
 void tst_CalendarEvent::recurExceptions()
@@ -235,10 +220,6 @@ void tst_CalendarEvent::testSave()
     NemoCalendarEvent *event = calendarApi.createEvent();
     QVERIFY(event != 0);
 
-    QLatin1String alarmProgram("alarmProgram");
-    event->setAlarmProgram(alarmProgram);
-    QCOMPARE(event->alarmProgram(), alarmProgram);
-
     bool allDay = false;
     event->setAllDay(allDay);
     QCOMPARE(event->allDay(), allDay);
@@ -302,7 +283,6 @@ void tst_CalendarEvent::testSave()
     QCOMPARE(eventB->endTime().toTime_t(), endTime.toTime_t());
     QCOMPARE(eventB->startTime().toTime_t(), startTime.toTime_t());
 
-    QCOMPARE(eventB->alarmProgram(), alarmProgram);
     QCOMPARE(eventB->allDay(), allDay);
     QCOMPARE(eventB->description(), description);
     QCOMPARE(eventB->displayLabel(), displayLabel);


### PR DESCRIPTION
Was setting alarm also for empty command.
As this is currently unused, the most simple fix is to just remove
functionality.
