### PR TITLE
[nemo-qml-plugin-calendar] Fix calendar event tests

### DIFF
--- a/tests/tst_calendarevent/tst_calendarevent.cpp
+++ b/tests/tst_calendarevent/tst_calendarevent.cpp
@@ -122,6 +122,12 @@ void tst_CalendarEvent::testSignals()
 
     NemoCalendarEventQuery query;
     query.setUniqueId(eventA->uniqueId());
+    for (int i = 0; i < 30; i++) {
+        if (query.event())
+            break;
+
+        QTest::qWait(100);
+    }
     NemoCalendarEvent *eventB = (NemoCalendarEvent*) query.event();
     QVERIFY(eventB != 0);
 
@@ -276,7 +282,14 @@ void tst_CalendarEvent::testSave()
 
     NemoCalendarEventQuery query;
     query.setUniqueId(event->uniqueId());
+    for (int i = 0; i < 30; i++) {
+        if (query.event())
+            break;
+
+        QTest::qWait(100);
+    }
     NemoCalendarEvent *eventB = (NemoCalendarEvent*) query.event();
+    QVERIFY(eventB != 0);
 
     // mKCal DB stores times as seconds, loosing millisecond accuracy.
     // Compare dates with QDateTime::toTime_t() instead of QDateTime::toMSecsSinceEpoch()


### PR DESCRIPTION
Recent changes [1] to NemoCalendarEventQuery requires that test code wait for query results, which may not be available immediatedly.

[1] https://github.com/nemomobile/nemo-qml-plugin-calendar/commit/50e15ef2bf450761fe42e218f8b0fb93663da680
