### PR TITLE
[nemo-qml-plugin-calendar] Fix setting invalid end date to recurrence

### DIFF
--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -192,8 +192,14 @@ void NemoCalendarWorker::saveEvent(const NemoCalendarData::Event &eventData)
     setReminder(event, eventData.reminder);
     setRecurrence(event, eventData.recur);
 
-    if (eventData.recur != NemoCalendarEvent::RecurOnce)
+    if (eventData.recur != NemoCalendarEvent::RecurOnce) {
         event->recurrence()->setEndDate(eventData.recurEndDate);
+        if (!eventData.recurEndDate.isValid()) {
+            // Recurrence/RecurrenceRule don't have separate method to clear the end date, and currently
+            // setting invalid date doesn't make the duration() indicate recurring infinitely.
+            event->recurrence()->setDuration(-1);
+        }
+    }
 
     if (createNew) {
         if (notebookUid.isEmpty())


### PR DESCRIPTION
KCalCore gets confused when setting invalid end date. On such, there
remains occurrences infinitely, but Recurrence::recursAt(),
getNextDateTime() don't work properly anymore.
