### PR TITLE
[nemo-qml-plugin-calendar] Fixed off-by-one problem in event range loading

### DIFF
--- a/src/calendarworker.cpp
+++ b/src/calendarworker.cpp
@@ -601,7 +601,7 @@ void NemoCalendarWorker::loadData(const QList<NemoCalendarData::Range> &ranges,
                                   bool reset)
 {
     foreach (const NemoCalendarData::Range &range, ranges)
-        mStorage->load(range.first, range.second);
+        mStorage->load(range.first, range.second.addDays(1)); // end date is not inclusive
 
     // Note: omitting recurrence ids since loadRecurringIncidences() loads them anyway
     foreach (const QString &uid, uidList)


### PR DESCRIPTION
ExtendedStorage::load(QDate, QDate) is not inclusive of end date
while AgendaModel is.
