### PR TITLE
Add calendar dbus data service and lightweight QML calendar data model

### DIFF
--- a/calendar.pro
+++ b/calendar.pro
@@ -1,5 +1,5 @@
 TEMPLATE = subdirs
-SUBDIRS = src tests
+SUBDIRS = src tests lightweight
 
 tests.depends = src
 

--- a/lightweight/calendardataservice/calendardataservice.cpp
+++ b/lightweight/calendardataservice/calendardataservice.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "calendardataservice.h"
+
+#include <QtCore/QDate>
+#include <QtCore/QDebug>
+#include <QtDBus/QDBusConnection>
+#include <QtDBus/QDBusMessage>
+
+#include "calendardataserviceadaptor.h"
+#include "../../src/calendaragendamodel.h"
+#include "../../src/calendarevent.h"
+#include "../../src/calendareventoccurrence.h"
+
+CalendarDataService::CalendarDataService(QObject *parent) :
+    QObject(parent), mAgendaModel(0)
+{
+    registerDataTypes();
+    new CalendarDataServiceAdaptor(this);
+    QDBusConnection connection = QDBusConnection::sessionBus();
+    if (!connection.registerService("org.nemomobile.calendardataservice"))
+        qWarning("Can't register org.nemomobile.calendardataservice service on the session bus");
+
+    if (!connection.registerObject("/org/nemomobile/calendardataservice", this))
+        qWarning("Can't register org/nemomobile/calendardataservice object for the D-Bus service.");
+}
+
+void CalendarDataService::getEvents(const QString &startDate, const QString &endDate)
+{
+    QDate start = QDate::fromString(startDate, Qt::ISODate);
+    QDate end = QDate::fromString(endDate, Qt::ISODate);
+    if (!start.isValid() || !end.isValid()) {
+        qWarning() << "Invalid date parameter(s):" << startDate << ", " << endDate;
+        exit(1);
+    }
+    initialize();
+    mAgendaModel->setStartDate(start);
+    mAgendaModel->setEndDate(end);
+}
+
+void CalendarDataService::updated()
+{
+    EventDataList reply;
+    for (int i = 0; i < mAgendaModel->count(); i++) {
+        QVariant variant = mAgendaModel->get(i, NemoCalendarAgendaModel::EventObjectRole);
+        QVariant occurrenceVariant = mAgendaModel->get(i, NemoCalendarAgendaModel::OccurrenceObjectRole);
+        if (variant.canConvert<NemoCalendarEvent *>() && occurrenceVariant.canConvert<NemoCalendarEventOccurrence *>()) {
+            NemoCalendarEvent* event = variant.value<NemoCalendarEvent *>();
+            NemoCalendarEventOccurrence* occurrence = occurrenceVariant.value<NemoCalendarEventOccurrence *>();
+            EventData eventStruct;
+            eventStruct.displayLabel = event->displayLabel();
+            eventStruct.description = event->description();
+            eventStruct.startTime = occurrence->startTime().toString(Qt::ISODate);
+            eventStruct.endTime = occurrence->endTime().toString(Qt::ISODate);
+            eventStruct.allDay = event->allDay();
+            eventStruct.color = event->color();
+            eventStruct.recurrenceId = event->recurrenceIdString();
+            eventStruct.uniqueId = event->uniqueId();
+            reply << eventStruct;
+        }
+    }
+    emit getEventsResult(reply);
+    exit(0);
+}
+
+void CalendarDataService::initialize()
+{
+    if (!mAgendaModel) {
+        mAgendaModel = new NemoCalendarAgendaModel(this);
+        connect(mAgendaModel, SIGNAL(updated()), this, SLOT(updated()));
+    }
+}

--- a/lightweight/calendardataservice/calendardataservice.cpp
+++ b/lightweight/calendardataservice/calendardataservice.cpp
@@ -46,8 +46,9 @@ CalendarDataService::CalendarDataService(QObject *parent) :
     QObject(parent), mAgendaModel(0), mTransactionIdCounter(0)
 {
     mKillTimer.setSingleShot(true);
-    mKillTimer.setInterval(1000);
+    mKillTimer.setInterval(2000);
     connect(&mKillTimer, SIGNAL(timeout()), this, SLOT(shutdown()));
+    mKillTimer.start();
 
     registerCalendarDataServiceTypes();
     new CalendarDataServiceAdaptor(this);
@@ -57,6 +58,9 @@ CalendarDataService::CalendarDataService(QObject *parent) :
 
     if (!connection.registerObject("/org/nemomobile/calendardataservice", this))
         qWarning("Can't register org/nemomobile/calendardataservice object for the D-Bus service.");
+
+    if (connection.lastError().isValid())
+        QCoreApplication::exit(1);
 }
 
 QString CalendarDataService::getEvents(const QString &startDate, const QString &endDate)
@@ -113,7 +117,7 @@ void CalendarDataService::updated()
 
 void CalendarDataService::shutdown()
 {
-    exit(0);
+    QCoreApplication::exit(0);
 }
 
 void CalendarDataService::initialize()

--- a/lightweight/calendardataservice/calendardataservice.cpp
+++ b/lightweight/calendardataservice/calendardataservice.cpp
@@ -45,7 +45,7 @@
 CalendarDataService::CalendarDataService(QObject *parent) :
     QObject(parent), mAgendaModel(0)
 {
-    registerDataTypes();
+    registerCalendarDataServiceTypes();
     new CalendarDataServiceAdaptor(this);
     QDBusConnection connection = QDBusConnection::sessionBus();
     if (!connection.registerService("org.nemomobile.calendardataservice"))

--- a/lightweight/calendardataservice/calendardataservice.h
+++ b/lightweight/calendardataservice/calendardataservice.h
@@ -45,7 +45,7 @@ class CalendarDataService : public QObject {
     Q_OBJECT
 
 public:
-    CalendarDataService(QObject *parent = 0);
+    explicit CalendarDataService(QObject *parent = 0);
 
     void fetchEvents();
 

--- a/lightweight/calendardataservice/calendardataservice.h
+++ b/lightweight/calendardataservice/calendardataservice.h
@@ -33,7 +33,9 @@
 #ifndef CALENDARDATASERVICE_H
 #define CALENDARDATASERVICE_H
 
-#include <QObject>
+#include <QtCore/QObject>
+#include <QtCore/QDate>
+#include <QtCore/QTimer>
 
 #include "../common/eventdata.h"
 
@@ -48,18 +50,30 @@ public:
     void fetchEvents();
 
 signals:
-    void getEventsResult(const EventDataList &eventDataList);
+    void getEventsResult(const QString &transactionId, const EventDataList &eventDataList);
 
 public slots:
-    void getEvents(const QString &startDate, const QString &endDate);
+    QString getEvents(const QString &startDate, const QString &endDate);
 
 private slots:
     void updated();
+    void shutdown();
+    void processQueue();
 
 private:
+    struct DataRequest {
+        QDate start;
+        QDate end;
+        QString transactionId;
+    };
+
     void initialize();
 
     NemoCalendarAgendaModel *mAgendaModel;
+    QTimer mKillTimer;
+    int mTransactionIdCounter;
+    QList<DataRequest> mDataRequestQueue;
+    DataRequest mCurrentDataRequest;
 };
 
 #endif // CALENDARDATASERVICE_H

--- a/lightweight/calendardataservice/calendardataservice.h
+++ b/lightweight/calendardataservice/calendardataservice.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef CALENDARDATASERVICE_H
+#define CALENDARDATASERVICE_H
+
+#include <QObject>
+
+#include "../common/eventdata.h"
+
+class NemoCalendarAgendaModel;
+
+class CalendarDataService : public QObject {
+    Q_OBJECT
+
+public:
+    CalendarDataService(QObject *parent = 0);
+
+    void fetchEvents();
+
+signals:
+    void getEventsResult(const EventDataList &eventDataList);
+
+public slots:
+    void getEvents(const QString &startDate, const QString &endDate);
+
+private slots:
+    void updated();
+
+private:
+    void initialize();
+
+    NemoCalendarAgendaModel *mAgendaModel;
+};
+
+#endif // CALENDARDATASERVICE_H

--- a/lightweight/calendardataservice/calendardataservice.pro
+++ b/lightweight/calendardataservice/calendardataservice.pro
@@ -1,0 +1,41 @@
+TEMPLATE = app
+TARGET = calendardataservice
+target.path = /usr/bin
+
+QT += qml dbus
+QT -= gui
+
+CONFIG += link_pkgconfig
+PKGCONFIG += libkcalcoren-qt5 libmkcal-qt5 libical
+
+HEADERS += \
+    calendardataservice.h \
+    calendardataserviceadaptor.h \
+    ../common/eventdata.h \
+    ../../src/calendaragendamodel.h \
+    ../../src/calendarmanager.h \
+    ../../src/calendarworker.h \
+    ../../src/calendareventoccurrence.h \
+    ../../src/calendarevent.h \
+    ../../src/calendarchangeinformation.h \
+    ../../src/calendareventquery.h
+
+SOURCES += \
+    calendardataservice.cpp \
+    calendardataserviceadaptor.cpp \
+    ../common/eventdata.cpp \
+    ../../src/calendaragendamodel.cpp \
+    ../../src/calendarmanager.cpp \
+    ../../src/calendarworker.cpp \
+    ../../src/calendareventoccurrence.cpp \
+    ../../src/calendarevent.cpp \
+    ../../src/calendarchangeinformation.cpp \
+    ../../src/calendareventquery.cpp \
+    main.cpp
+
+dbus_service.path = /usr/share/dbus-1/services/
+dbus_service.files = org.nemomobile.calendardataservice.service
+
+INSTALLS += target dbus_service
+
+OTHER_FILES += *.service *.xml

--- a/lightweight/calendardataservice/calendardataserviceadaptor.cpp
+++ b/lightweight/calendardataservice/calendardataserviceadaptor.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "calendardataserviceadaptor.h"
+
+#include <QtCore/QMetaObject>
+
+/*
+ * Implementation of adaptor class CalendarDataServiceAdaptor
+ */
+
+CalendarDataServiceAdaptor::CalendarDataServiceAdaptor(QObject *parent) :
+    QDBusAbstractAdaptor(parent)
+{
+    setAutoRelaySignals(true);
+}
+
+CalendarDataServiceAdaptor::~CalendarDataServiceAdaptor()
+{
+}
+
+void CalendarDataServiceAdaptor::getEvents(const QString &startDate, const QString &endDate)
+{
+    // handle method call org.nemomobile.calendardataservice.getEvents
+    QMetaObject::invokeMethod(parent(), "getEvents", Q_ARG(QString, startDate), Q_ARG(QString, endDate));
+}
+

--- a/lightweight/calendardataservice/calendardataserviceadaptor.cpp
+++ b/lightweight/calendardataservice/calendardataserviceadaptor.cpp
@@ -48,9 +48,13 @@ CalendarDataServiceAdaptor::~CalendarDataServiceAdaptor()
 {
 }
 
-void CalendarDataServiceAdaptor::getEvents(const QString &startDate, const QString &endDate)
+QString CalendarDataServiceAdaptor::getEvents(const QString &startDate, const QString &endDate)
 {
     // handle method call org.nemomobile.calendardataservice.getEvents
-    QMetaObject::invokeMethod(parent(), "getEvents", Q_ARG(QString, startDate), Q_ARG(QString, endDate));
+    QString transactionId;
+    QMetaObject::invokeMethod(parent(), "getEvents",
+                              Q_RETURN_ARG(QString, transactionId),
+                              Q_ARG(QString, startDate),
+                              Q_ARG(QString, endDate));
+    return transactionId;
 }
-

--- a/lightweight/calendardataservice/calendardataserviceadaptor.h
+++ b/lightweight/calendardataservice/calendardataserviceadaptor.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef CALENDARTOOLADAPTOR_H_1422885580
+#define CALENDARTOOLADAPTOR_H_1422885580
+
+#include <QtCore/QObject>
+#include <QtDBus/QtDBus>
+
+#include "../common/eventdata.h"
+
+/*
+ * Adaptor class for interface org.nemomobile.calendardataservice
+ */
+class CalendarDataServiceAdaptor: public QDBusAbstractAdaptor
+{
+    Q_OBJECT
+    Q_CLASSINFO("D-Bus Interface", "org.nemomobile.calendardataservice")
+    Q_CLASSINFO("D-Bus Introspection", ""
+                "  <interface name=\"org.nemomobile.calendardataservice\">\n"
+                "    <method name=\"getEvents\">\n"
+                "      <arg direction=\"in\" type=\"s\" name=\"startDate\"/>\n"
+                "      <arg direction=\"in\" type=\"s\" name=\"endDate\"/>\n"
+                "    </method>\n"
+                "    <signal name=\"getEventsResult\">\n"
+                "      <arg type=\"a(sssssbssss)\" name=\"eventList\"/>\n"
+                "    </signal>\n"
+                "  </interface>\n"
+                "")
+
+public:
+    CalendarDataServiceAdaptor(QObject *parent);
+    virtual ~CalendarDataServiceAdaptor();
+
+public Q_SLOTS:
+    void getEvents(const QString &startDate, const QString &endDate);
+
+Q_SIGNALS:
+    void getEventsResult(const EventDataList &eventDataList);
+};
+
+#endif

--- a/lightweight/calendardataservice/calendardataserviceadaptor.h
+++ b/lightweight/calendardataservice/calendardataserviceadaptor.h
@@ -50,9 +50,11 @@ class CalendarDataServiceAdaptor: public QDBusAbstractAdaptor
                 "    <method name=\"getEvents\">\n"
                 "      <arg direction=\"in\" type=\"s\" name=\"startDate\"/>\n"
                 "      <arg direction=\"in\" type=\"s\" name=\"endDate\"/>\n"
+                "      <arg direction=\"out\" type=\"s\" name=\"transactionId\"/>\n"
                 "    </method>\n"
                 "    <signal name=\"getEventsResult\">\n"
-                "      <arg type=\"a(sssssbssss)\" name=\"eventList\"/>\n"
+                "      <arg type=\"s\" name=\"transactionId\"/>\n"
+                "      <arg type=\"a(sssssbssss)\" name=\"eventDataList\"/>\n"
                 "    </signal>\n"
                 "  </interface>\n"
                 "")
@@ -62,10 +64,10 @@ public:
     virtual ~CalendarDataServiceAdaptor();
 
 public Q_SLOTS:
-    void getEvents(const QString &startDate, const QString &endDate);
+    QString getEvents(const QString &startDate, const QString &endDate);
 
 Q_SIGNALS:
-    void getEventsResult(const EventDataList &eventDataList);
+    void getEventsResult(const QString &transactionId, const EventDataList &eventDataList);
 };
 
 #endif

--- a/lightweight/calendardataservice/main.cpp
+++ b/lightweight/calendardataservice/main.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QtCore/QCoreApplication>
+
+#include "calendardataservice.h"
+
+int main(int argc, char *argv[])
+{
+    QCoreApplication app(argc, argv);
+    CalendarDataService calendarDataService;
+    Q_UNUSED(calendarDataService)
+    return app.exec();
+}

--- a/lightweight/calendardataservice/org.nemomobile.calendardataservice.service
+++ b/lightweight/calendardataservice/org.nemomobile.calendardataservice.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Interface=/org/nemomobile/calendardataservice
+Name=org.nemomobile.calendardataservice
+Exec=/usr/bin/calendardataservice

--- a/lightweight/calendareventsmodel/calendardataserviceproxy.cpp
+++ b/lightweight/calendareventsmodel/calendardataserviceproxy.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "calendardataserviceproxy.h"
+
+CalendarDataServiceProxy::CalendarDataServiceProxy(const QString &service, const QString &path, const QDBusConnection &connection, QObject *parent) :
+    QDBusAbstractInterface(service, path, staticInterfaceName(), connection, parent)
+{
+}
+
+CalendarDataServiceProxy::~CalendarDataServiceProxy()
+{
+}
+

--- a/lightweight/calendareventsmodel/calendardataserviceproxy.h
+++ b/lightweight/calendareventsmodel/calendardataserviceproxy.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef CALENDARDATASERVICEPROXY_H
+#define CALENDARDATASERVICEPROXY_H
+
+#include <QtCore/QObject>
+#include <QtCore/QVariant>
+#include <QtDBus/QtDBus>
+
+#include "../common/eventdata.h"
+
+/*
+ * Proxy class for interface org.nemomobile.calendardataservice
+ */
+class CalendarDataServiceProxy: public QDBusAbstractInterface
+{
+    Q_OBJECT
+public:
+    static inline const char *staticInterfaceName()
+    { return "org.nemomobile.calendardataservice"; }
+
+public:
+    CalendarDataServiceProxy(const QString &service, const QString &path, const QDBusConnection &connection, QObject *parent = 0);
+
+    ~CalendarDataServiceProxy();
+
+public Q_SLOTS:
+    inline QDBusPendingReply<> getEvents(const QString &startDate, const QString &endDate)
+    {
+        QList<QVariant> argumentList;
+        argumentList << QVariant::fromValue(startDate) << QVariant::fromValue(endDate);
+        return asyncCallWithArgumentList(QLatin1String("getEvents"), argumentList);
+    }
+
+Q_SIGNALS:
+    void getEventsResult(const EventDataList &eventDataList);
+};
+
+namespace org {
+namespace nemomobile {
+typedef ::CalendarDataServiceProxy calendardataservice;
+}
+}
+#endif // CALENDARDATASERVICEPROXY_H

--- a/lightweight/calendareventsmodel/calendardataserviceproxy.h
+++ b/lightweight/calendareventsmodel/calendardataserviceproxy.h
@@ -55,7 +55,7 @@ public:
     ~CalendarDataServiceProxy();
 
 public Q_SLOTS:
-    inline QDBusPendingReply<> getEvents(const QString &startDate, const QString &endDate)
+    inline QDBusPendingReply<QString> getEvents(const QString &startDate, const QString &endDate)
     {
         QList<QVariant> argumentList;
         argumentList << QVariant::fromValue(startDate) << QVariant::fromValue(endDate);
@@ -63,12 +63,12 @@ public Q_SLOTS:
     }
 
 Q_SIGNALS:
-    void getEventsResult(const EventDataList &eventDataList);
+    void getEventsResult(const QString &transactionId, const EventDataList &eventDataList);
 };
 
 namespace org {
-namespace nemomobile {
-typedef ::CalendarDataServiceProxy calendardataservice;
-}
+    namespace nemomobile {
+        typedef ::CalendarDataServiceProxy calendardataservice;
+    }
 }
 #endif // CALENDARDATASERVICEPROXY_H

--- a/lightweight/calendareventsmodel/calendareventsmodel.cpp
+++ b/lightweight/calendareventsmodel/calendareventsmodel.cpp
@@ -211,7 +211,7 @@ QVariant NemoCalendarEventsModel::data(const QModelIndex &index, int role) const
 
 void NemoCalendarEventsModel::update()
 {
-    mTransactionId = "";
+    mTransactionId.clear();
     QDateTime endDate = (mEndDate.isValid()) ? mEndDate : mStartDate;
     QDBusPendingCall pcall = mProxy->getEvents(mStartDate.toString(Qt::ISODate),
                                                endDate.toString(Qt::ISODate));

--- a/lightweight/calendareventsmodel/calendareventsmodel.cpp
+++ b/lightweight/calendareventsmodel/calendareventsmodel.cpp
@@ -52,7 +52,7 @@ NemoCalendarEventsModel::NemoCalendarEventsModel(QObject *parent) :
     mEventLimit(1000),
     mTotalCount(0)
 {
-    registerDataTypes();
+    registerCalendarDataServiceTypes();
     mProxy = new CalendarDataServiceProxy("org.nemomobile.calendardataservice",
                                           "/org/nemomobile/calendardataservice",
                                           QDBusConnection::sessionBus(),

--- a/lightweight/calendareventsmodel/calendareventsmodel.cpp
+++ b/lightweight/calendareventsmodel/calendareventsmodel.cpp
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "calendareventsmodel.h"
+
+#include <QDBusInterface>
+#include <QDBusPendingReply>
+#include <QDBusPendingCallWatcher>
+#include <QDebug>
+#include <QFileSystemWatcher>
+#include <QTimer>
+#include <qqmlinfo.h>
+
+#include "calendardataserviceproxy.h"
+
+NemoCalendarEventsModel::NemoCalendarEventsModel(QObject *parent) :
+    QAbstractListModel(parent),
+    mProxy(0),
+    mWatcher(new QFileSystemWatcher(this)),
+    mUpdateDelayTimer(new QTimer(this)),
+    mFilterMode(FilterNone),
+    mContentType(ContentAll),
+    mEventLimit(1000),
+    mTotalCount(0)
+{
+    registerDataTypes();
+    mProxy = new CalendarDataServiceProxy("org.nemomobile.calendardataservice",
+                                          "/org/nemomobile/calendardataservice",
+                                          QDBusConnection::sessionBus(),
+                                          this);
+    connect(mProxy, SIGNAL(getEventsResult(EventDataList)),
+            this, SLOT(getEventsResult(EventDataList)));
+
+    mUpdateDelayTimer->setInterval(500);
+    mUpdateDelayTimer->setSingleShot(true);
+    connect(mUpdateDelayTimer, SIGNAL(timeout()), this, SLOT(update()));
+
+    QString privilegedDataDir = QString("%1/.local/share/system/privileged/Calendar/mkcal/db").arg(QDir::homePath());
+    mWatcher->addPath(privilegedDataDir);
+    QSettings settings("nemo", "nemo-qml-plugin-calendar");
+    mWatcher->addPath(settings.fileName());
+    // Updates to the calendar db will cause several file change notifications, delay update a bit
+    connect(mWatcher, SIGNAL(fileChanged(QString)), mUpdateDelayTimer, SLOT(start()));
+}
+
+int NemoCalendarEventsModel::count() const
+{
+    return qMin(mEventDataList.count(), mEventLimit);
+}
+
+int NemoCalendarEventsModel::totalCount() const
+{
+    return mTotalCount;
+}
+
+QDateTime NemoCalendarEventsModel::creationDate() const
+{
+    return mCreationDate;
+}
+
+QDateTime NemoCalendarEventsModel::expiryDate() const
+{
+    return mExpiryDate;
+}
+
+int NemoCalendarEventsModel::eventLimit() const
+{
+    return mEventLimit;
+}
+
+void NemoCalendarEventsModel::setEventLimit(int limit)
+{
+    if (mEventLimit == limit || limit <= 0)
+        return;
+
+    mEventLimit = limit;
+    emit eventLimitChanged();
+    restartUpdateTimer(); // TODO: Could change list content without fetching data
+}
+
+QDateTime NemoCalendarEventsModel::startDate() const
+{
+    return mStartDate;
+}
+
+void NemoCalendarEventsModel::setStartDate(const QDateTime &startDate)
+{
+    if (mStartDate == startDate)
+        return;
+
+    mStartDate = startDate;
+    emit startDateChanged();
+
+    restartUpdateTimer();
+}
+
+QDateTime NemoCalendarEventsModel::endDate() const
+{
+    return mEndDate;
+}
+
+void NemoCalendarEventsModel::setEndDate(const QDateTime &endDate)
+{
+    if (mEndDate == endDate)
+        return;
+
+    mEndDate = endDate;
+    emit endDateChanged();
+
+    restartUpdateTimer();
+}
+
+int NemoCalendarEventsModel::filterMode() const
+{
+    return mFilterMode;
+}
+
+void NemoCalendarEventsModel::setFilterMode(int mode)
+{
+    if (mFilterMode == mode)
+        return;
+
+    mFilterMode = mode;
+    emit filterModeChanged();
+    restartUpdateTimer();
+}
+
+
+int NemoCalendarEventsModel::contentType() const
+{
+    return mContentType;
+}
+
+void NemoCalendarEventsModel::setContentType(int contentType)
+{
+    if (mContentType == contentType)
+        return;
+
+    mContentType = contentType;
+    emit contentTypeChanged();
+    restartUpdateTimer();
+}
+
+int NemoCalendarEventsModel::rowCount(const QModelIndex &index) const
+{
+    if (index != QModelIndex())
+        return 0;
+
+    return mEventDataList.count();
+}
+
+QVariant NemoCalendarEventsModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() >= mEventDataList.count())
+        return QVariant();
+
+    EventData eventData = mEventDataList.at(index.row());
+
+    switch(role) {
+    case DisplayLabelRole:
+        return eventData.displayLabel;
+    case DescriptionRole:
+        return eventData.description;
+    case StartTimeRole:
+        return eventData.startTime;
+    case EndTimeRole:
+        return eventData.endTime;
+    case RecurrenceIdRole:
+        return eventData.recurrenceId;
+    case AllDayRole:
+        return eventData.allDay;
+    case LocationRole:
+        return eventData.location;
+    case CalendarUidRole:
+        return eventData.calendarUid;
+    case UidRole:
+        return eventData.uniqueId;
+    case ColorRole:
+        return eventData.color;
+    default:
+        return QVariant();
+    }
+}
+
+void NemoCalendarEventsModel::update()
+{
+    QDateTime endDate = (mEndDate.isValid()) ? mEndDate : mStartDate;
+    QDBusPendingCall pcall = mProxy->getEvents(mStartDate.toString(Qt::ISODate),
+                                               endDate.toString(Qt::ISODate));
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(pcall, this);
+    QObject::connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
+                     this, SLOT(updateFinished(QDBusPendingCallWatcher*)));
+}
+
+void NemoCalendarEventsModel::updateFinished(QDBusPendingCallWatcher *call)
+{
+    QDBusPendingReply<void> reply = *call;
+    if (reply.isError())
+        qWarning() << "dbus error:" << reply.error().name() << reply.error().message();
+
+    call->deleteLater();
+}
+
+void NemoCalendarEventsModel::getEventsResult(const EventDataList &eventDataList)
+{
+    if (mEventDataList.isEmpty() && eventDataList.isEmpty())
+        return;
+
+    int oldcount = mEventDataList.count();
+    int oldTotalCount = mTotalCount;
+    beginResetModel();
+    mEventDataList.clear();
+    QDateTime now = QDateTime::currentDateTime();
+    QDateTime expiryDate;
+    mTotalCount = 0;
+    foreach (const EventData &e, eventDataList) {
+        if ((e.allDay && mContentType == ContentEvents)
+                || (!e.allDay && mContentType == ContentAllDay)) {
+            continue;
+        }
+
+        QDateTime startTime = QDateTime::fromString(e.startTime, Qt::ISODate);
+        QDateTime endTime = QDateTime::fromString(e.endTime, Qt::ISODate);
+        if (e.allDay
+                || (mFilterMode == FilterPast && now < endTime)
+                || (mFilterMode == FilterPastAndCurrent && now < startTime)
+                || (mFilterMode == FilterNone)) {
+            if (mEventDataList.count() < mEventLimit) {
+                mEventDataList.append(e);
+                if (!e.allDay) {
+                    if (mFilterMode == FilterPast && (!expiryDate.isValid() || expiryDate > endTime)) {
+                        expiryDate = endTime;
+                    } else if (mFilterMode == FilterPastAndCurrent && (!expiryDate.isValid() || expiryDate > startTime)) {
+                        expiryDate = startTime;
+                    }
+                }
+            }
+            mTotalCount++;
+        }
+    }
+
+    mCreationDate = QDateTime::currentDateTime();
+    emit creationDateChanged();
+
+    if (!expiryDate.isValid()) {
+        if (mEndDate.isValid()) {
+            expiryDate = mEndDate;
+        } else {
+            expiryDate = mStartDate.addDays(1);
+            expiryDate.setTime(QTime(0,0,0,1));
+        }
+    }
+    mExpiryDate = expiryDate;
+    emit expiryDateChanged();
+
+    endResetModel();
+    if (count() != oldcount) {
+        emit countChanged();
+    }
+    if (mTotalCount != oldTotalCount) {
+        emit totalCountChanged();
+    }
+}
+
+QHash<int, QByteArray> NemoCalendarEventsModel::roleNames() const
+{
+    QHash<int, QByteArray> roleNames;
+    roleNames[DisplayLabelRole] = "displayLabel";
+    roleNames[DescriptionRole] = "description";
+    roleNames[StartTimeRole] = "startTime";
+    roleNames[EndTimeRole] = "endTime";
+    roleNames[RecurrenceIdRole] = "recurrenceId";
+    roleNames[AllDayRole] = "allDay";
+    roleNames[LocationRole] = "location";
+    roleNames[CalendarUidRole] = "calendarUid";
+    roleNames[UidRole] = "uid";
+    roleNames[ColorRole] = "color";
+
+    return roleNames;
+}
+
+void NemoCalendarEventsModel::restartUpdateTimer()
+{
+    if (mStartDate.isValid())
+        mUpdateDelayTimer->start();
+    else
+        mUpdateDelayTimer->stop();
+}

--- a/lightweight/calendareventsmodel/calendareventsmodel.h
+++ b/lightweight/calendareventsmodel/calendareventsmodel.h
@@ -128,7 +128,7 @@ public slots:
 
 private slots:
     void updateFinished(QDBusPendingCallWatcher *call);
-    void getEventsResult(const EventDataList &eventDataList);
+    void getEventsResult(const QString &transactionId, const EventDataList &eventDataList);
 
 protected:
     virtual QHash<int, QByteArray> roleNames() const;
@@ -148,6 +148,7 @@ private:
     int mContentType;
     int mEventLimit;
     int mTotalCount;
+    QString mTransactionId;
 };
 
 #endif // CALENDAREVENTSMODEL_H

--- a/lightweight/calendareventsmodel/calendareventsmodel.h
+++ b/lightweight/calendareventsmodel/calendareventsmodel.h
@@ -57,6 +57,7 @@ class NemoCalendarEventsModel : public QAbstractListModel
     Q_PROPERTY(int eventLimit READ eventLimit WRITE setEventLimit NOTIFY eventLimitChanged)
     Q_PROPERTY(int contentType READ contentType WRITE setContentType NOTIFY contentTypeChanged)
     Q_PROPERTY(int totalCount READ totalCount NOTIFY totalCountChanged)
+    Q_PROPERTY(int eventDisplayTime READ eventDisplayTime WRITE setEventDisplayTime NOTIFY eventDisplayTimeChanged)
 
 public:
     enum FilterMode {
@@ -109,6 +110,9 @@ public:
     int eventLimit() const;
     void setEventLimit(int limit);
 
+    int eventDisplayTime() const;
+    void setEventDisplayTime(int seconds);
+
     virtual int rowCount(const QModelIndex &index) const;
     virtual QVariant data(const QModelIndex &index, int role) const;
 
@@ -122,6 +126,7 @@ signals:
     void expiryDateChanged();
     void eventLimitChanged();
     void totalCountChanged();
+    void eventDisplayTimeChanged();
 
 public slots:
     void update();
@@ -148,6 +153,7 @@ private:
     int mContentType;
     int mEventLimit;
     int mTotalCount;
+    int mEventDisplayTime;
     QString mTransactionId;
 };
 

--- a/lightweight/calendareventsmodel/calendareventsmodel.h
+++ b/lightweight/calendareventsmodel/calendareventsmodel.h
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef CALENDAREVENTSMODEL_H
+#define CALENDAREVENTSMODEL_H
+
+#include <QAbstractListModel>
+#include <QDateTime>
+
+#include "../common/eventdata.h"
+
+class QDBusPendingCallWatcher;
+class CalendarDataServiceProxy;
+class QFileSystemWatcher;
+class QTimer;
+
+class NemoCalendarEventsModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_ENUMS(FilterMode)
+    Q_ENUMS(ContentType)
+    Q_PROPERTY(QDateTime startDate READ startDate WRITE setStartDate NOTIFY startDateChanged)
+    Q_PROPERTY(QDateTime endDate READ endDate WRITE setEndDate NOTIFY endDateChanged)
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(int filterMode READ filterMode WRITE setFilterMode NOTIFY filterModeChanged)
+    Q_PROPERTY(QDateTime creationDate READ creationDate NOTIFY creationDateChanged)
+    Q_PROPERTY(QDateTime expiryDate READ expiryDate NOTIFY expiryDateChanged)
+    Q_PROPERTY(int eventLimit READ eventLimit WRITE setEventLimit NOTIFY eventLimitChanged)
+    Q_PROPERTY(int contentType READ contentType WRITE setContentType NOTIFY contentTypeChanged)
+    Q_PROPERTY(int totalCount READ totalCount NOTIFY totalCountChanged)
+
+public:
+    enum FilterMode {
+        FilterNone,
+        FilterPast,
+        FilterPastAndCurrent
+    };
+
+    enum ContentType {
+        ContentAllDay,
+        ContentEvents,
+        ContentAll
+    };
+
+    enum {
+        DisplayLabelRole = Qt::UserRole,
+        DescriptionRole,
+        StartTimeRole,
+        EndTimeRole,
+        RecurrenceIdRole,
+        AllDayRole,
+        LocationRole,
+        CalendarUidRole,
+        UidRole,
+        ColorRole
+    };
+
+    explicit NemoCalendarEventsModel(QObject *parent = 0);
+
+    QDateTime startDate() const;
+    void setStartDate(const QDateTime &startDate);
+
+    QDateTime endDate() const;
+    void setEndDate(const QDateTime &endDate);
+
+    int filterMode() const;
+    void setFilterMode(int mode);
+
+    int contentType() const;
+    void setContentType(int contentType);
+
+    int count() const;
+
+    int totalCount() const;
+
+    QDateTime creationDate() const;
+
+    QDateTime expiryDate() const;
+
+    int eventLimit() const;
+    void setEventLimit(int limit);
+
+    virtual int rowCount(const QModelIndex &index) const;
+    virtual QVariant data(const QModelIndex &index, int role) const;
+
+signals:
+    void startDateChanged();
+    void endDateChanged();
+    void countChanged();
+    void filterModeChanged();
+    void contentTypeChanged();
+    void creationDateChanged();
+    void expiryDateChanged();
+    void eventLimitChanged();
+    void totalCountChanged();
+
+public slots:
+    void update();
+
+private slots:
+    void updateFinished(QDBusPendingCallWatcher *call);
+    void getEventsResult(const EventDataList &eventDataList);
+
+protected:
+    virtual QHash<int, QByteArray> roleNames() const;
+
+private:
+    void restartUpdateTimer();
+
+    CalendarDataServiceProxy *mProxy;
+    QFileSystemWatcher *mWatcher;
+    QTimer *mUpdateDelayTimer;
+    EventDataList mEventDataList;
+    QDateTime mStartDate;
+    QDateTime mEndDate;
+    QDateTime mCreationDate;
+    QDateTime mExpiryDate;
+    int mFilterMode;
+    int mContentType;
+    int mEventLimit;
+    int mTotalCount;
+};
+
+#endif // CALENDAREVENTSMODEL_H

--- a/lightweight/calendareventsmodel/calendareventsmodel.h
+++ b/lightweight/calendareventsmodel/calendareventsmodel.h
@@ -35,13 +35,13 @@
 
 #include <QAbstractListModel>
 #include <QDateTime>
+#include <QTimer>
 
 #include "../common/eventdata.h"
 
 class QDBusPendingCallWatcher;
 class CalendarDataServiceProxy;
 class QFileSystemWatcher;
-class QTimer;
 
 class NemoCalendarEventsModel : public QAbstractListModel
 {
@@ -138,7 +138,7 @@ private:
 
     CalendarDataServiceProxy *mProxy;
     QFileSystemWatcher *mWatcher;
-    QTimer *mUpdateDelayTimer;
+    QTimer mUpdateDelayTimer;
     EventDataList mEventDataList;
     QDateTime mStartDate;
     QDateTime mEndDate;

--- a/lightweight/calendareventsmodel/calendareventsmodel.pro
+++ b/lightweight/calendareventsmodel/calendareventsmodel.pro
@@ -1,0 +1,30 @@
+TARGET = nemocalendarwidget
+PLUGIN_IMPORT_PATH = org/nemomobile/calendar/lightweight
+
+TEMPLATE = lib
+CONFIG += qt plugin hide_symbols
+
+QT += qml dbus
+QT -= gui
+
+target.path = $$[QT_INSTALL_QML]/$$PLUGIN_IMPORT_PATH
+INSTALLS += target
+
+qmldir.files += $$_PRO_FILE_PWD_/qmldir
+qmldir.path +=  $$target.path
+INSTALLS += qmldir
+
+isEmpty(SRCDIR) SRCDIR = "."
+SOURCES += \
+    calendardataserviceproxy.cpp \
+    calendareventsmodel.cpp \
+    ../common/eventdata.cpp \
+    plugin.cpp
+
+HEADERS += \
+    calendardataserviceproxy.h \
+    calendareventsmodel.h \
+    ../common/eventdata.h
+
+MOC_DIR = $$PWD/.moc
+OBJECTS_DIR = $$PWD/.obj

--- a/lightweight/calendareventsmodel/plugin.cpp
+++ b/lightweight/calendareventsmodel/plugin.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QtGlobal>
+#include <QtQml>
+
+#include "calendareventsmodel.h"
+
+class Q_DECL_EXPORT NemoCalendarPlugin : public QQmlExtensionPlugin
+{
+    Q_OBJECT
+    Q_PLUGIN_METADATA(IID "org.nemomobile.calendar.lightweight")
+
+public:
+    void initializeEngine(QQmlEngine *engine, const char *uri)
+    {
+        Q_UNUSED(engine)
+        Q_UNUSED(uri)
+    }
+
+    void registerTypes(const char *uri)
+    {
+        Q_ASSERT(uri == QLatin1String("org.nemomobile.calendar.lightweight"));
+        qmlRegisterType<NemoCalendarEventsModel>("org.nemomobile.calendar.lightweight", 1, 0, "CalendarEventsModel");
+    }
+};
+
+#include "plugin.moc"

--- a/lightweight/calendareventsmodel/qmldir
+++ b/lightweight/calendareventsmodel/qmldir
@@ -1,0 +1,2 @@
+module org.nemomobile.calendar.lightweight
+plugin nemocalendarwidget

--- a/lightweight/common/eventdata.cpp
+++ b/lightweight/common/eventdata.cpp
@@ -3,10 +3,16 @@
 QDBusArgument &operator<<(QDBusArgument &argument, const EventData &eventData)
 {
     argument.beginStructure();
-    argument << eventData.displayLabel << eventData.description << eventData.startTime
-             << eventData.endTime << eventData.recurrenceId << eventData.allDay
-             << eventData.location << eventData.calendarUid << eventData.uniqueId
-             << eventData.color;
+    argument << eventData.calendarUid
+             << eventData.uniqueId
+             << eventData.recurrenceId
+             << eventData.startTime
+             << eventData.endTime
+             << eventData.allDay
+             << eventData.color
+             << eventData.displayLabel
+             << eventData.description
+             << eventData.location;
     argument.endStructure();
     return argument;
 }
@@ -14,10 +20,16 @@ QDBusArgument &operator<<(QDBusArgument &argument, const EventData &eventData)
 const QDBusArgument &operator>>(const QDBusArgument &argument, EventData &eventData)
 {
     argument.beginStructure();
-    argument >> eventData.displayLabel >> eventData.description >> eventData.startTime
-             >> eventData.endTime >> eventData.recurrenceId >> eventData.allDay
-             >> eventData.location >> eventData.calendarUid >> eventData.uniqueId
-             >> eventData.color;
+    argument >> eventData.calendarUid
+             >> eventData.uniqueId
+             >> eventData.recurrenceId
+             >> eventData.startTime
+             >> eventData.endTime
+             >> eventData.allDay
+             >> eventData.color
+             >> eventData.displayLabel
+             >> eventData.description
+             >> eventData.location;
     argument.endStructure();
     return argument;
 }

--- a/lightweight/common/eventdata.cpp
+++ b/lightweight/common/eventdata.cpp
@@ -1,0 +1,23 @@
+#include "eventdata.h"
+
+QDBusArgument &operator<<(QDBusArgument &argument, const EventData &eventData)
+{
+    argument.beginStructure();
+    argument << eventData.displayLabel << eventData.description << eventData.startTime
+             << eventData.endTime << eventData.recurrenceId << eventData.allDay
+             << eventData.location << eventData.calendarUid << eventData.uniqueId
+             << eventData.color;
+    argument.endStructure();
+    return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument, EventData &eventData)
+{
+    argument.beginStructure();
+    argument >> eventData.displayLabel >> eventData.description >> eventData.startTime
+             >> eventData.endTime >> eventData.recurrenceId >> eventData.allDay
+             >> eventData.location >> eventData.calendarUid >> eventData.uniqueId
+             >> eventData.color;
+    argument.endStructure();
+    return argument;
+}

--- a/lightweight/common/eventdata.h
+++ b/lightweight/common/eventdata.h
@@ -6,16 +6,17 @@
 #include <QtDBus/QDBusMetaType>
 
 struct EventData {
-    QString displayLabel;
-    QString description;
-    QString startTime;
-    QString endTime;
-    QString recurrenceId;
-    bool allDay;
-    QString location;
     QString calendarUid;
     QString uniqueId;
+    QString recurrenceId;
+    QString startTime;
+    QString endTime;
+    bool allDay;
     QString color;
+    QString displayLabel;
+    QString description;
+    QString location;
+
 };
 Q_DECLARE_METATYPE(EventData)
 
@@ -25,7 +26,7 @@ const QDBusArgument &operator>>(const QDBusArgument &argument, EventData &eventD
 typedef QList<EventData> EventDataList;
 Q_DECLARE_METATYPE(EventDataList)
 
-inline void registerDataTypes() {
+inline void registerCalendarDataServiceTypes() {
     qDBusRegisterMetaType<EventData>();
     qDBusRegisterMetaType<EventDataList>();
 }

--- a/lightweight/common/eventdata.h
+++ b/lightweight/common/eventdata.h
@@ -1,0 +1,33 @@
+#ifndef EVENTDATA_H
+#define EVENTDATA_H
+
+#include <QtCore/QList>
+#include <QtCore/QString>
+#include <QtDBus/QDBusMetaType>
+
+struct EventData {
+    QString displayLabel;
+    QString description;
+    QString startTime;
+    QString endTime;
+    QString recurrenceId;
+    bool allDay;
+    QString location;
+    QString calendarUid;
+    QString uniqueId;
+    QString color;
+};
+Q_DECLARE_METATYPE(EventData)
+
+QDBusArgument &operator<<(QDBusArgument &argument, const EventData &eventData);
+const QDBusArgument &operator>>(const QDBusArgument &argument, EventData &eventData);
+
+typedef QList<EventData> EventDataList;
+Q_DECLARE_METATYPE(EventDataList)
+
+inline void registerDataTypes() {
+    qDBusRegisterMetaType<EventData>();
+    qDBusRegisterMetaType<EventDataList>();
+}
+
+#endif // EVENTDATA_H

--- a/lightweight/lightweight.pro
+++ b/lightweight/lightweight.pro
@@ -1,0 +1,2 @@
+TEMPLATE = subdirs
+SUBDIRS = calendardataservice

--- a/lightweight/lightweight.pro
+++ b/lightweight/lightweight.pro
@@ -1,2 +1,2 @@
 TEMPLATE = subdirs
-SUBDIRS = calendardataservice
+SUBDIRS = calendardataservice calendareventsmodel

--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -29,12 +29,6 @@ Requires:   %{name} = %{version}-%{release}
 %package lightweight
 Summary:    Calendar lightweight QML plugin
 Group:      System/Libraries
-BuildRequires:  pkgconfig(Qt5Core)
-BuildRequires:  pkgconfig(Qt5Qml)
-BuildRequires:  pkgconfig(Qt5Concurrent)
-BuildRequires:  pkgconfig(libmkcal-qt5)
-BuildRequires:  pkgconfig(libkcalcoren-qt5)
-BuildRequires:  pkgconfig(libical)
 
 %description lightweight
 %{summary}.

--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -26,6 +26,19 @@ Requires:   %{name} = %{version}-%{release}
 %description tests
 %{summary}.
 
+%package lightweight
+Summary:    Calendar lightweight QML plugin
+Group:      System/Libraries
+BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5Qml)
+BuildRequires:  pkgconfig(Qt5Concurrent)
+BuildRequires:  pkgconfig(libmkcal-qt5)
+BuildRequires:  pkgconfig(libkcalcoren-qt5)
+BuildRequires:  pkgconfig(libical)
+
+%description lightweight
+%{summary}.
+
 %prep
 %setup -q -n %{name}-%{version}
 
@@ -47,3 +60,10 @@ rm -rf %{buildroot}
 %files tests
 %defattr(-,root,root,-)
 /opt/tests/nemo-qml-plugins-qt5/calendar/*
+
+%files lightweight
+%defattr(-,root,root,-)
+%attr(2755, root, privileged) %{_bindir}/calendardataservice
+%{_datadir}/dbus-1/services/org.nemomobile.calendardataservice.service
+%{_libdir}/qt5/qml/org/nemomobile/calendar/lightweight/libnemocalendarwidget.so
+%{_libdir}/qt5/qml/org/nemomobile/calendar/lightweight/qmldir

--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -29,6 +29,7 @@ Requires:   %{name} = %{version}-%{release}
 %package lightweight
 Summary:    Calendar lightweight QML plugin
 Group:      System/Libraries
+BuildRequires:  pkgconfig(Qt5DBus)
 
 %description lightweight
 %{summary}.


### PR DESCRIPTION
The QML plugin that nemo-qml-plugin-calendar provides requires (potentially) very much memory. This makes it quite cumbersome for trivial applications that simply want to show calendar data without modifying it.

This changeset adds a dbus service, which can be used to get calendar data via dbus. The service is implemented by a simple binary, which serves the dbus request, and then quits, freeing memory.

In addition, this changeset includes a QML data model using the service, which provides much of the same functionality that the AgendaModel does, only as a read-only version. The data model monitors the calendar database and settings file, updating the model when either changes.

The data service and model are packaged in the subpackage *-lightweight.