### PR TITLE
[nemo-qml-plugin-calendar] Expose notebook account information

### DIFF
--- a/lightweight/calendardataservice/calendardataservice.pro
+++ b/lightweight/calendardataservice/calendardataservice.pro
@@ -6,7 +6,7 @@ QT += qml dbus
 QT -= gui
 
 CONFIG += link_pkgconfig
-PKGCONFIG += libkcalcoren-qt5 libmkcal-qt5 libical
+PKGCONFIG += libkcalcoren-qt5 libmkcal-qt5 libical accounts-qt5
 
 HEADERS += \
     calendardataservice.h \

--- a/rpm/nemo-qml-plugin-calendar-qt5.spec
+++ b/rpm/nemo-qml-plugin-calendar-qt5.spec
@@ -13,6 +13,7 @@ BuildRequires:  pkgconfig(Qt5Concurrent)
 BuildRequires:  pkgconfig(libmkcal-qt5)
 BuildRequires:  pkgconfig(libkcalcoren-qt5)
 BuildRequires:  pkgconfig(libical)
+BuildRequires:  pkgconfig(accounts-qt5)
 
 %description
 %{summary}.

--- a/src/calendardata.h
+++ b/src/calendardata.h
@@ -2,6 +2,7 @@
 #define NEMOCALENDARDATA_H
 
 #include <QString>
+#include <QUrl>
 
 // KCalCore
 #include <attendee.h>
@@ -54,18 +55,21 @@ struct Notebook {
     QString uid;
     QString description;
     QString color;
+    int accountId;
+    QUrl accountIcon;
     bool isDefault;
     bool readOnly;
     bool localCalendar;
     bool excluded;
 
-    Notebook() : isDefault(false), readOnly(false), localCalendar(false), excluded(false) { }
+    Notebook() : accountId(0), isDefault(false), readOnly(false), localCalendar(false), excluded(false) { }
 
     bool operator==(const Notebook other) const
     {
         return uid == other.uid && name == other.name && description == other.description &&
-                color == other.color && isDefault == other.isDefault && readOnly == other.readOnly &&
-                localCalendar == other.localCalendar && excluded == other.excluded;
+               color == other.color && accountId == other.accountId && accountIcon == other.accountIcon &&
+               isDefault == other.isDefault && readOnly == other.readOnly && localCalendar == other.localCalendar &&
+               excluded == other.excluded;
     }
 
     bool operator!=(const Notebook other) const

--- a/src/calendarnotebookmodel.cpp
+++ b/src/calendarnotebookmodel.cpp
@@ -73,6 +73,10 @@ QVariant NemoCalendarNotebookModel::data(const QModelIndex &index, int role) con
         return notebook.readOnly;
     case LocalCalendarRole:
         return notebook.localCalendar;
+    case AccountIdRole:
+        return notebook.accountId;
+    case AccountIconRole:
+        return notebook.accountIcon;
     default:
         return QVariant();
     }
@@ -120,6 +124,8 @@ QHash<int, QByteArray> NemoCalendarNotebookModel::roleNames() const
     roleNames[DefaultRole] = "isDefault";
     roleNames[ReadOnlyRole] = "readOnly";
     roleNames[LocalCalendarRole] = "localCalendar";
+    roleNames[AccountIdRole] = "accountId";
+    roleNames[AccountIconRole] = "accountIcon";
 
     return roleNames;
 }

--- a/src/calendarnotebookmodel.h
+++ b/src/calendarnotebookmodel.h
@@ -46,7 +46,9 @@ public:
         ColorRole,
         DefaultRole,
         ReadOnlyRole,
-        LocalCalendarRole
+        LocalCalendarRole,
+        AccountIdRole,
+        AccountIconRole
     };
 
     NemoCalendarNotebookModel();

--- a/src/calendarnotebookquery.cpp
+++ b/src/calendarnotebookquery.cpp
@@ -47,6 +47,16 @@ QString NemoCalendarNotebookQuery::color() const
     return m_notebook.color;
 }
 
+int NemoCalendarNotebookQuery::accountId() const
+{
+    return m_notebook.accountId;
+}
+
+QUrl NemoCalendarNotebookQuery::accountIcon() const
+{
+    return m_notebook.accountIcon;
+}
+
 bool NemoCalendarNotebookQuery::isDefault() const
 {
     return m_notebook.isDefault;
@@ -82,6 +92,8 @@ void NemoCalendarNotebookQuery::updateData()
     bool nameUpdated = (notebook.name != m_notebook.name);
     bool descriptionUpdated = (notebook.description != m_notebook.description);
     bool colorUpdated = (notebook.color != m_notebook.color);
+    bool accountIdUpdated = (notebook.accountId != m_notebook.accountId);
+    bool accountIconUpdated = (notebook.accountIcon != m_notebook.accountIcon);
     bool isDefaultUpdated = (notebook.isDefault != m_notebook.isDefault);
     bool localCalendarUpdated = (notebook.localCalendar != m_notebook.localCalendar);
     bool isReadOnlyUpdated = (notebook.readOnly != m_notebook.readOnly);
@@ -94,6 +106,10 @@ void NemoCalendarNotebookQuery::updateData()
         emit descriptionChanged();
     if (colorUpdated)
         emit colorChanged();
+    if (accountIdUpdated)
+        emit accountIdChanged();
+    if (accountIconUpdated)
+        emit accountIconChanged();
     if (isDefaultUpdated)
         emit isDefaultChanged();
     if (localCalendarUpdated)

--- a/src/calendarnotebookquery.h
+++ b/src/calendarnotebookquery.h
@@ -12,6 +12,8 @@ class NemoCalendarNotebookQuery : public QObject
     Q_PROPERTY(QString name READ name NOTIFY nameChanged)
     Q_PROPERTY(QString description READ description NOTIFY descriptionChanged)
     Q_PROPERTY(QString color READ color NOTIFY colorChanged)
+    Q_PROPERTY(int accountId READ accountId NOTIFY accountIdChanged)
+    Q_PROPERTY(QUrl accountIcon READ accountIcon NOTIFY accountIconChanged)
     Q_PROPERTY(bool isDefault READ isDefault NOTIFY isDefaultChanged)
     Q_PROPERTY(bool localCalendar READ localCalendar NOTIFY localCalendarChanged)
     Q_PROPERTY(bool isReadOnly READ isReadOnly NOTIFY isReadOnlyChanged)
@@ -27,6 +29,8 @@ public:
     QString name() const;
     QString description() const;
     QString color() const;
+    int accountId() const;
+    QUrl accountIcon() const;
     bool isDefault() const;
     bool localCalendar() const;
     bool isReadOnly() const;
@@ -37,6 +41,8 @@ signals:
     void nameChanged();
     void descriptionChanged();
     void colorChanged();
+    void accountIdChanged();
+    void accountIconChanged();
     void isDefaultChanged();
     void localCalendarChanged();
     void isReadOnlyChanged();

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -41,6 +41,9 @@
 // mkcal
 #include <extendedstorage.h>
 
+// libaccounts-qt
+namespace Accounts { class Manager; }
+
 class NemoCalendarWorker : public QObject, public mKCal::ExtendedStorageObserver
 {
     Q_OBJECT
@@ -113,6 +116,8 @@ private:
     QHash<QDate, QStringList> dailyEventOccurrences(const QList<NemoCalendarData::Range> &ranges,
                                                     const QMultiHash<QString, KDateTime> &allDay,
                                                     const QList<NemoCalendarData::EventOccurrence> &occurrences);
+
+    Accounts::Manager *mAccountManager;
 
     mKCal::ExtendedCalendar::Ptr mCalendar;
     mKCal::ExtendedStorage::Ptr mStorage;

--- a/src/src.pro
+++ b/src/src.pro
@@ -8,7 +8,7 @@ QT += qml concurrent
 QT -= gui
 
 target.path = $$[QT_INSTALL_QML]/$$PLUGIN_IMPORT_PATH
-PKGCONFIG += libkcalcoren-qt5 libmkcal-qt5 libical
+PKGCONFIG += libkcalcoren-qt5 libmkcal-qt5 libical accounts-qt5
 
 INSTALLS += target
 


### PR DESCRIPTION
Some notebooks are associated with particular accounts (ie, synced).
This commit exposes this account information (id and icon) in the
notebook data so that it can be displayed in the UI if required.