### PR TITLE
Add model for showing and importing vCalendar and iCalendar events from file

### DIFF
--- a/calendar.pro
+++ b/calendar.pro
@@ -3,4 +3,4 @@ SUBDIRS = src tests lightweight
 
 tests.depends = src
 
-OTHER_FILES += rpm/*
+OTHER_FILES += rpm/* qmldir

--- a/lightweight/calendardataservice/calendardataservice.pro
+++ b/lightweight/calendardataservice/calendardataservice.pro
@@ -18,7 +18,8 @@ HEADERS += \
     ../../src/calendareventoccurrence.h \
     ../../src/calendarevent.h \
     ../../src/calendarchangeinformation.h \
-    ../../src/calendareventquery.h
+    ../../src/calendareventquery.h \
+    ../../src/calendarutils.h
 
 SOURCES += \
     calendardataservice.cpp \
@@ -31,6 +32,7 @@ SOURCES += \
     ../../src/calendarevent.cpp \
     ../../src/calendarchangeinformation.cpp \
     ../../src/calendareventquery.cpp \
+    ../../src/calendarutils.cpp \
     main.cpp
 
 dbus_service.path = /usr/share/dbus-1/services/

--- a/src/calendareventquery.cpp
+++ b/src/calendareventquery.cpp
@@ -34,6 +34,7 @@
 
 #include "calendarmanager.h"
 #include "calendareventoccurrence.h"
+#include "calendarutils.h"
 
 NemoCalendarEventQuery::NemoCalendarEventQuery()
     : mIsComplete(true), mOccurrence(0), mAttendeesCached(false)
@@ -138,20 +139,12 @@ QObject *NemoCalendarEventQuery::occurrence() const
 
 QList<QObject*> NemoCalendarEventQuery::attendees()
 {
-    QList<QObject*> result;
-
     if (!mAttendeesCached) {
         mAttendees = NemoCalendarManager::instance()->getEventAttendees(mUid, mRecurrenceId);
         mAttendeesCached = true;
     }
 
-    foreach (const NemoCalendarData::Attendee &attendee, mAttendees) {
-        QObject *person = new Person(attendee.name, attendee.email, attendee.isOrganizer,
-                                     attendee.participationRole);
-        result.append(person);
-    }
-
-    return result;
+    return NemoCalendarUtils::convertAttendeeList(mAttendees);
 }
 
 void NemoCalendarEventQuery::classBegin()

--- a/src/calendarimportevent.cpp
+++ b/src/calendarimportevent.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "calendarimportevent.h"
+
+#include "calendareventoccurrence.h"
+#include "calendarutils.h"
+
+CalendarImportEvent::CalendarImportEvent(KCalCore::Event::Ptr event)
+    : QObject(),
+      mEvent(event),
+      mColor("#ffffff")
+{
+}
+
+QString CalendarImportEvent::displayLabel() const
+{
+    if (!mEvent)
+        return "";
+
+    return mEvent->summary();
+}
+
+QString CalendarImportEvent::description() const
+{
+    if (!mEvent)
+        return "";
+
+    return mEvent->description();
+}
+
+QDateTime CalendarImportEvent::startTime() const
+{
+    if (!mEvent)
+        return QDateTime();
+
+    return mEvent->dtStart().dateTime();
+}
+
+QDateTime CalendarImportEvent::endTime() const
+{
+    if (!mEvent)
+        return QDateTime();
+
+    return mEvent->dtEnd().dateTime();
+}
+
+bool CalendarImportEvent::allDay() const
+{
+    if (!mEvent)
+        return false;
+
+    return mEvent->allDay();
+}
+
+NemoCalendarEvent::Recur CalendarImportEvent::recur()
+{
+    if (!mEvent)
+        return NemoCalendarEvent::RecurOnce;
+
+    return NemoCalendarUtils::convertRecurrence(mEvent);
+}
+
+NemoCalendarEvent::Reminder CalendarImportEvent::reminder() const
+{
+    if (!mEvent)
+        return NemoCalendarEvent::ReminderNone;
+
+    return NemoCalendarUtils::getReminder(mEvent);
+}
+
+QString CalendarImportEvent::uniqueId() const
+{
+    if (!mEvent)
+        return "";
+
+    return mEvent->uid();
+}
+
+QString CalendarImportEvent::color() const
+{
+    return mColor;
+}
+
+QString CalendarImportEvent::location() const
+{
+    if (!mEvent)
+        return "";
+
+    return mEvent->location();
+}
+
+QList<QObject *> CalendarImportEvent::attendees() const
+{
+    if (!mEvent)
+        return QList<QObject *>();
+
+    return NemoCalendarUtils::convertAttendeeList(NemoCalendarUtils::getEventAttendees(mEvent));
+}
+
+void CalendarImportEvent::setColor(const QString &color)
+{
+    if (mColor == color)
+        return;
+
+    mColor = color;
+    emit colorChanged();
+}
+
+QObject *CalendarImportEvent::nextOccurrence()
+{
+    if (!mEvent)
+        return 0;
+
+    NemoCalendarData::EventOccurrence eo = NemoCalendarUtils::getNextOccurrence(mEvent);
+    return new NemoCalendarEventOccurrence(eo.eventUid,
+                                           eo.recurrenceId,
+                                           eo.startTime,
+                                           eo.endTime);
+}

--- a/src/calendarimportevent.h
+++ b/src/calendarimportevent.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef CALENDARIMPORTEVENT_H
+#define CALENDARIMPORTEVENT_H
+
+#include <QObject>
+
+// kCalCore
+#include <event.h>
+
+#include "calendarevent.h"
+
+class CalendarImportEvent : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString displayLabel READ displayLabel CONSTANT)
+    Q_PROPERTY(QString description READ description CONSTANT)
+    Q_PROPERTY(QDateTime startTime READ startTime CONSTANT)
+    Q_PROPERTY(QDateTime endTime READ endTime CONSTANT)
+    Q_PROPERTY(bool allDay READ allDay CONSTANT)
+    Q_PROPERTY(NemoCalendarEvent::Recur recur READ recur CONSTANT)
+    Q_PROPERTY(NemoCalendarEvent::Reminder reminder READ reminder CONSTANT)
+    Q_PROPERTY(QString uniqueId READ uniqueId CONSTANT)
+    Q_PROPERTY(QString color READ color WRITE setColor NOTIFY colorChanged)
+    Q_PROPERTY(QString location READ location CONSTANT)
+    Q_PROPERTY(QList<QObject*> attendees READ attendees CONSTANT)
+
+public:
+    CalendarImportEvent(KCalCore::Event::Ptr event);
+
+    QString displayLabel() const;
+    QString description() const;
+    QDateTime startTime() const;
+    QDateTime endTime() const;
+    bool allDay() const;
+    NemoCalendarEvent::Recur recur();
+    NemoCalendarEvent::Reminder reminder() const;
+    QString uniqueId() const;
+    QString color() const;
+    QString location() const;
+    QList<QObject*> attendees() const;
+
+    void setColor(const QString &color);
+
+public slots:
+    QObject *nextOccurrence();
+
+signals:
+    void colorChanged();
+
+private:
+    KCalCore::Event::Ptr mEvent;
+    QString mColor;
+};
+#endif // CALENDARIMPORTEVENT_H

--- a/src/calendarimportmodel.cpp
+++ b/src/calendarimportmodel.cpp
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "calendarimportmodel.h"
+
+#include <QtCore/QDebug>
+#include <QtCore/QFile>
+#include <QtCore/QUrl>
+
+// mkcal
+#include <extendedcalendar.h>
+#include <extendedstorage.h>
+
+// kcalcore
+#include <icalformat.h>
+#include <vcalformat.h>
+#include <memorycalendar.h>
+
+#include "calendarimportevent.h"
+
+NemoCalendarImportModel::NemoCalendarImportModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+}
+
+NemoCalendarImportModel::~NemoCalendarImportModel()
+{
+}
+
+int NemoCalendarImportModel::count() const
+{
+    return mEventList.count();
+}
+
+QString NemoCalendarImportModel::fileName() const
+{
+    return mFileName;
+}
+
+void NemoCalendarImportModel::setFileName(const QString &fileName)
+{
+    if (mFileName == fileName)
+        return;
+
+    mFileName = fileName;
+    emit fileNameChanged();
+    if (!mFileName.isEmpty()) {
+        importToMemory(fileName);
+    } else if (!mEventList.isEmpty()) {
+        beginResetModel();
+        mEventList.clear();
+        endResetModel();
+        emit countChanged();
+    }
+}
+
+QObject *NemoCalendarImportModel::getEvent(int index)
+{
+    if (index < 0 || index >= mEventList.count())
+        return 0;
+
+    return new CalendarImportEvent(mEventList.at(index));
+}
+
+int NemoCalendarImportModel::rowCount(const QModelIndex &index) const
+{
+    if (index != QModelIndex())
+        return 0;
+
+    return mEventList.count();
+}
+
+QVariant NemoCalendarImportModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid() || index.row() >= mEventList.count())
+        return QVariant();
+
+    KCalCore::Event::Ptr event = mEventList.at(index.row());
+
+    switch(role) {
+    case DisplayLabelRole:
+        return event->summary();
+    case DescriptionRole:
+        return event->description();
+    case StartTimeRole:
+        return event->dtStart().dateTime();
+    case EndTimeRole:
+        return event->dtEnd().dateTime();
+    case AllDayRole:
+        return event->allDay();
+    case LocationRole:
+        return event->location();
+    case UidRole:
+        return event->uid();
+    default:
+        return QVariant();
+    }
+}
+
+bool NemoCalendarImportModel::importToNotebook(const QString &notebookUid)
+{
+    mKCal::ExtendedCalendar::Ptr calendar(new mKCal::ExtendedCalendar(KDateTime::Spec::LocalZone()));
+    mKCal::ExtendedStorage::Ptr storage = calendar->defaultStorage(calendar);
+    if (!storage->open()) {
+        qWarning() << "Unable to open calendar DB";
+        return false;
+    }
+
+    if (!notebookUid.isEmpty()) {
+        if (! (storage->defaultNotebook() && storage->defaultNotebook()->uid() == notebookUid)) {
+            mKCal::Notebook::Ptr notebook = storage->notebook(notebookUid);
+            if (notebook) {
+                // TODO: should we change default notebook back if we change it?
+                storage->setDefaultNotebook(notebook);
+            } else {
+                qWarning() << "Invalid notebook UID" << notebookUid;
+                return false;
+            }
+        }
+    }
+
+    if (importFromFile(mFileName, calendar))
+        storage->save();
+
+    storage->close();
+
+    return true;
+}
+
+QHash<int, QByteArray> NemoCalendarImportModel::roleNames() const
+{
+    QHash<int, QByteArray> roleNames;
+    roleNames[DisplayLabelRole] = "displayLabel";
+    roleNames[DescriptionRole] = "description";
+    roleNames[StartTimeRole] = "startTime";
+    roleNames[EndTimeRole] = "endTime";
+    roleNames[AllDayRole] = "allDay";
+    roleNames[LocationRole] = "location";
+    roleNames[UidRole] = "uid";
+
+    return roleNames;
+}
+
+bool NemoCalendarImportModel::importFromFile(const QString &fileName,
+                                             KCalCore::Calendar::Ptr calendar)
+{
+    QString filePath;
+    QUrl url(fileName);
+    if (url.isLocalFile())
+        filePath = url.toLocalFile();
+    else
+        filePath = fileName;
+
+    if (!(filePath.endsWith(".vcs") || filePath.endsWith(".ics"))) {
+        qWarning() << "Unsupported file format" << filePath;
+        return false;
+    }
+
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qWarning() << "Unable to open file for reading" << filePath;
+        return false;
+    }
+    QString fileContent(file.readAll());
+
+    bool ok = false;
+    if (filePath.endsWith(".vcs")) {
+        KCalCore::VCalFormat vcalFormat;
+        ok = vcalFormat.fromString(calendar, fileContent);
+    } else if (filePath.endsWith(".ics")) {
+        KCalCore::ICalFormat icalFormat;
+        ok = icalFormat.fromString(calendar, fileContent);
+    }
+    if (!ok)
+        qWarning() << "Failed to import from file" << filePath;
+
+    return ok;
+}
+
+static bool incidenceLessThan(const KCalCore::Incidence::Ptr e1,
+                              const KCalCore::Incidence::Ptr e2)
+{
+    if (e1->dtStart() == e2->dtStart()) {
+        int cmp = QString::compare(e1->summary(),
+                                   e2->summary(),
+                                   Qt::CaseInsensitive);
+        if (cmp == 0)
+            return QString::compare(e1->uid(), e2->uid()) < 0;
+        else
+            return cmp < 0;
+    } else {
+        return e1->dtStart() < e2->dtStart();
+    }
+}
+
+bool NemoCalendarImportModel::importToMemory(const QString &fileName)
+{
+    if (!mEventList.isEmpty())
+        mEventList.clear();
+
+    beginResetModel();
+    KCalCore::MemoryCalendar::Ptr cal(new KCalCore::MemoryCalendar(KDateTime::Spec::LocalZone()));
+    importFromFile(fileName, cal);
+    KCalCore::Incidence::List incidenceList = cal->incidences();
+    for (int i = 0; i < incidenceList.size(); i++) {
+        KCalCore::Incidence::Ptr incidence = incidenceList.at(i);
+        if (incidence->type() == KCalCore::IncidenceBase::TypeEvent)
+            mEventList.append(incidence.staticCast<KCalCore::Event>());
+    }
+    if (!mEventList.isEmpty())
+        qSort(mEventList.begin(), mEventList.end(), incidenceLessThan);
+
+    endResetModel();
+    emit countChanged();
+    return true;
+}
+

--- a/src/calendarimportmodel.h
+++ b/src/calendarimportmodel.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef CALENDARIMPORT_H
+#define CALENDARIMPORT_H
+
+#include <QAbstractListModel>
+
+// kCalCore
+#include <calendar.h>
+
+class NemoCalendarImportModel : public QAbstractListModel
+{
+    Q_OBJECT
+    Q_PROPERTY(int count READ count NOTIFY countChanged)
+    Q_PROPERTY(QString fileName READ fileName WRITE setFileName NOTIFY fileNameChanged)
+
+public:
+    enum {
+        DisplayLabelRole = Qt::UserRole,
+        DescriptionRole,
+        StartTimeRole,
+        EndTimeRole,
+        AllDayRole,
+        LocationRole,
+        UidRole,
+    };
+
+    explicit NemoCalendarImportModel(QObject *parent = 0);
+    ~NemoCalendarImportModel();
+
+    int count() const;
+
+    QString fileName() const;
+    void setFileName(const QString& fileName);
+
+    virtual int rowCount(const QModelIndex &index) const;
+    virtual QVariant data(const QModelIndex &index, int role) const;
+
+public slots:
+    QObject *getEvent(int index);
+
+signals:
+    void countChanged();
+    void fileNameChanged();
+
+public slots:
+    bool importToNotebook(const QString &notebookUid = QString());
+
+protected:
+    virtual QHash<int, QByteArray> roleNames() const;
+
+private:
+    bool importFromFile(const QString &fileName, KCalCore::Calendar::Ptr calendar);
+    bool importToMemory(const QString &fileName);
+
+    QString mFileName;
+    KCalCore::Event::List mEventList;
+};
+
+#endif // CALENDARIMPORT_H

--- a/src/calendarutils.cpp
+++ b/src/calendarutils.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "calendarutils.h"
+
+#include "calendareventquery.h"
+
+NemoCalendarEvent::Recur NemoCalendarUtils::convertRecurrence(const KCalCore::Event::Ptr &event)
+{
+    if (!event->recurs())
+        return NemoCalendarEvent::RecurOnce;
+
+    if (event->recurrence()->rRules().count() != 1)
+        return NemoCalendarEvent::RecurCustom;
+
+    ushort rt = event->recurrence()->recurrenceType();
+    int freq = event->recurrence()->frequency();
+
+    if (rt == KCalCore::Recurrence::rDaily && freq == 1) {
+        return NemoCalendarEvent::RecurDaily;
+    } else if (rt == KCalCore::Recurrence::rWeekly && freq == 1) {
+        return NemoCalendarEvent::RecurWeekly;
+    } else if (rt == KCalCore::Recurrence::rWeekly && freq == 2) {
+        return NemoCalendarEvent::RecurBiweekly;
+    } else if (rt == KCalCore::Recurrence::rMonthlyDay && freq == 1) {
+        return NemoCalendarEvent::RecurMonthly;
+    } else if (rt == KCalCore::Recurrence::rYearlyMonth && freq == 1) {
+        return NemoCalendarEvent::RecurYearly;
+    }
+
+    return NemoCalendarEvent::RecurCustom;
+}
+
+NemoCalendarEvent::Reminder NemoCalendarUtils::getReminder(const KCalCore::Event::Ptr &event)
+{
+    KCalCore::Alarm::List alarms = event->alarms();
+
+    KCalCore::Alarm::Ptr alarm;
+
+    for (int ii = 0; ii < alarms.count(); ++ii) {
+        if (alarms.at(ii)->type() == KCalCore::Alarm::Procedure)
+            continue;
+
+        if (alarm)
+            return NemoCalendarEvent::ReminderNone;
+        else
+            alarm = alarms.at(ii);
+    }
+
+    if (!alarm)
+        return NemoCalendarEvent::ReminderNone;
+
+    KCalCore::Duration d = alarm->startOffset();
+    int sec = d.asSeconds();
+
+    switch (sec) {
+    case 0:
+        return NemoCalendarEvent::ReminderTime;
+    case -5 * 60:
+        return NemoCalendarEvent::Reminder5Min;
+    case -15 * 60:
+        return NemoCalendarEvent::Reminder15Min;
+    case -30 * 60:
+        return NemoCalendarEvent::Reminder30Min;
+    case -60 * 60:
+        return NemoCalendarEvent::Reminder1Hour;
+    case -2 * 60 * 60:
+        return NemoCalendarEvent::Reminder2Hour;
+    case -24 * 60 * 60:
+        return NemoCalendarEvent::Reminder1Day;
+    case -2 * 24 * 60 * 60:
+        return NemoCalendarEvent::Reminder2Day;
+    default:
+        return NemoCalendarEvent::ReminderNone;
+    }
+}
+
+QList<NemoCalendarData::Attendee> NemoCalendarUtils::getEventAttendees(const KCalCore::Event::Ptr &event)
+{
+    QList<NemoCalendarData::Attendee> result;
+    KCalCore::Person::Ptr calOrganizer = event->organizer();
+
+    NemoCalendarData::Attendee organizer;
+
+    if (!calOrganizer.isNull() && !calOrganizer->isEmpty()) {
+        organizer.isOrganizer = true;
+        organizer.name = calOrganizer->name();
+        organizer.email = calOrganizer->email();
+        organizer.participationRole = KCalCore::Attendee::ReqParticipant;
+        result.append(organizer);
+    }
+
+    KCalCore::Attendee::List attendees = event->attendees();
+    NemoCalendarData::Attendee attendee;
+    attendee.isOrganizer = false;
+
+    foreach (KCalCore::Attendee::Ptr calAttendee, attendees) {
+        attendee.name = calAttendee->name();
+        attendee.email = calAttendee->email();
+        if (attendee.name == organizer.name && attendee.email == organizer.email) {
+            // avoid duplicate info
+            continue;
+        }
+        attendee.participationRole = calAttendee->role();
+        result.append(attendee);
+    }
+
+    return result;
+}
+
+QList<QObject *> NemoCalendarUtils::convertAttendeeList(const QList<NemoCalendarData::Attendee> &list)
+{
+    QList<QObject*> result;
+    foreach (const NemoCalendarData::Attendee &attendee, list) {
+        QObject *person = new Person(attendee.name, attendee.email, attendee.isOrganizer,
+                                     attendee.participationRole);
+        result.append(person);
+    }
+
+    return result;
+}
+
+NemoCalendarData::EventOccurrence NemoCalendarUtils::getNextOccurrence(const KCalCore::Event::Ptr &event,
+                                                                       const QDateTime &start)
+{
+    NemoCalendarData::EventOccurrence occurrence;
+    if (event) {
+        QDateTime dtStart = event->dtStart().toLocalZone().dateTime();
+        QDateTime dtEnd = event->dtEnd().toLocalZone().dateTime();
+
+        if (!start.isNull() && event->recurs()) {
+            KDateTime startTime = KDateTime(start, KDateTime::Spec(KDateTime::LocalZone));
+            KCalCore::Recurrence *recurrence = event->recurrence();
+            if (recurrence->recursAt(startTime)) {
+                dtStart = startTime.toLocalZone().dateTime();
+                dtEnd = KCalCore::Duration(event->dtStart(), event->dtEnd()).end(startTime).toLocalZone().dateTime();
+            } else {
+                KDateTime match = recurrence->getNextDateTime(startTime);
+                if (match.isNull())
+                    match = recurrence->getPreviousDateTime(startTime);
+
+                if (!match.isNull()) {
+                    dtStart = match.toLocalZone().dateTime();
+                    dtEnd = KCalCore::Duration(event->dtStart(), event->dtEnd()).end(match).toLocalZone().dateTime();
+                }
+            }
+        }
+
+        occurrence.eventUid = event->uid();
+        occurrence.recurrenceId = event->recurrenceId();
+        occurrence.startTime = dtStart;
+        occurrence.endTime = dtEnd;
+    }
+
+    return occurrence;
+}

--- a/src/calendarutils.h
+++ b/src/calendarutils.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Petri M. Gerdt <petri.gerdt@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef UTILS_H
+#define UTILS_H
+
+#include "calendarevent.h"
+#include "calendardata.h"
+
+// kCalCore
+#include <event.h>
+
+namespace NemoCalendarUtils {
+
+NemoCalendarEvent::Recur convertRecurrence(const KCalCore::Event::Ptr &event);
+NemoCalendarEvent::Reminder getReminder(const KCalCore::Event::Ptr &event);
+QList<NemoCalendarData::Attendee> getEventAttendees(const KCalCore::Event::Ptr &event);
+QList<QObject*> convertAttendeeList(const QList<NemoCalendarData::Attendee> &list);
+NemoCalendarData::EventOccurrence getNextOccurrence(const KCalCore::Event::Ptr &event,
+                                                    const QDateTime &start = QDateTime::currentDateTime());
+
+} // namespace NemoCalendarUtils
+
+#endif // UTILS_H

--- a/src/calendarworker.h
+++ b/src/calendarworker.h
@@ -108,9 +108,7 @@ private:
     bool setRecurrence(KCalCore::Event::Ptr &event, NemoCalendarEvent::Recur recur);
     bool setReminder(KCalCore::Event::Ptr &event, NemoCalendarEvent::Reminder reminder);
 
-    NemoCalendarEvent::Recur convertRecurrence(const KCalCore::Event::Ptr &event) const;
     KCalCore::Duration reminderToDuration(NemoCalendarEvent::Reminder reminder) const;
-    NemoCalendarEvent::Reminder getReminder(const KCalCore::Event::Ptr &event) const;
     NemoCalendarData::Event createEventStruct(const KCalCore::Event::Ptr &event) const;
     QHash<QString, NemoCalendarData::EventOccurrence> eventOccurrences(const QList<NemoCalendarData::Range> &ranges) const;
     QHash<QDate, QStringList> dailyEventOccurrences(const QList<NemoCalendarData::Range> &ranges,

--- a/src/plugin.cpp
+++ b/src/plugin.cpp
@@ -44,6 +44,7 @@
 #include "calendaragendamodel.h"
 #include "calendarmanager.h"
 #include "calendarnotebookquery.h"
+#include "calendarimportmodel.h"
 
 class QtDate : public QObject
 {
@@ -125,6 +126,7 @@ public:
         qmlRegisterType<NemoCalendarNotebookQuery>(uri, 1, 0, "NotebookQuery");
         qmlRegisterSingletonType<QtDate>(uri, 1, 0, "QtDate", QtDate::New);
         qmlRegisterSingletonType<NemoCalendarApi>(uri, 1, 0, "Calendar", NemoCalendarApi::New);
+        qmlRegisterType<NemoCalendarImportModel>(uri, 1, 0, "ImportModel");
     }
 };
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -33,7 +33,9 @@ SOURCES += \
     $$SRCDIR/calendarnotebookquery.cpp \
     $$SRCDIR/calendareventmodification.cpp \
     $$SRCDIR/calendarchangeinformation.cpp \
-    $$SRCDIR/calendarutils.cpp
+    $$SRCDIR/calendarutils.cpp \
+    $$SRCDIR/calendarimportmodel.cpp \
+    $$SRCDIR/calendarimportevent.cpp
 
 HEADERS += \
     $$SRCDIR/calendarevent.h \
@@ -48,7 +50,9 @@ HEADERS += \
     $$SRCDIR/calendarnotebookquery.h \
     $$SRCDIR/calendareventmodification.h \
     $$SRCDIR/calendarchangeinformation.h \
-    $$SRCDIR/calendarutils.h
+    $$SRCDIR/calendarutils.h \
+    $$SRCDIR/calendarimportmodel.h \
+    $$SRCDIR/calendarimportevent.h
 
 MOC_DIR = $$PWD/.moc
 OBJECTS_DIR = $$PWD/.obj

--- a/src/src.pro
+++ b/src/src.pro
@@ -32,7 +32,8 @@ SOURCES += \
     $$SRCDIR/calendarworker.cpp \
     $$SRCDIR/calendarnotebookquery.cpp \
     $$SRCDIR/calendareventmodification.cpp \
-    $$SRCDIR/calendarchangeinformation.cpp
+    $$SRCDIR/calendarchangeinformation.cpp \
+    $$SRCDIR/calendarutils.cpp
 
 HEADERS += \
     $$SRCDIR/calendarevent.h \
@@ -46,7 +47,8 @@ HEADERS += \
     $$SRCDIR/calendardata.h \
     $$SRCDIR/calendarnotebookquery.h \
     $$SRCDIR/calendareventmodification.h \
-    $$SRCDIR/calendarchangeinformation.h
+    $$SRCDIR/calendarchangeinformation.h \
+    $$SRCDIR/calendarutils.h
 
 MOC_DIR = $$PWD/.moc
 OBJECTS_DIR = $$PWD/.obj


### PR DESCRIPTION
The contents of a vCalendar or iCalendar file are read to memory, and a model is populated with the event data from the file. Incidences that are not events are discarded. Events can then be imported to a notebook.